### PR TITLE
refactor(llm): unify development and production to use Vertex AI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,12 +199,32 @@ homework-coach-robo/
 - `should_move_to_next_phase()`: 次のヒントレベルへの遷移判定
 
 **LLM統合:**
-- `GeminiClient`: Google Gemini API (`gemini-2.5-flash`) を使用
-- 開発環境: `GOOGLE_API_KEY` または `GEMINI_API_KEY` で設定
-- 本番環境: Vertex AI 経由（`GOOGLE_GENAI_USE_VERTEXAI=TRUE`）
-- APIキー未設定時はテンプレートベースのフォールバック応答
+- `GeminiClient`: Vertex AI 経由で Gemini API (`gemini-2.5-flash`) を使用
+- 開発/本番ともに Vertex AI を使用（Application Default Credentials）
+- プロジェクトID未設定時はテンプレートベースのフォールバック応答
 
-**テストカバレッジ**: 98%（201テスト）
+**環境変数:**
+| 変数名 | 必須 | 説明 |
+|--------|------|------|
+| `GOOGLE_CLOUD_PROJECT` | ✅ | GCPプロジェクトID |
+| `GOOGLE_CLOUD_LOCATION` | ❌ | リージョン（デフォルト: us-central1） |
+
+**ローカル開発セットアップ:**
+```bash
+# 1. gcloud CLI をインストール（未インストールの場合）
+# https://cloud.google.com/sdk/docs/install
+
+# 2. 認証情報を設定
+gcloud auth application-default login
+
+# 3. プロジェクトIDを設定
+export GOOGLE_CLOUD_PROJECT=your-project-id
+
+# 4. バックエンドを起動
+cd backend && uv run uvicorn app.main:app --reload
+```
+
+**テストカバレッジ**: 98%（202テスト）
 
 ### 次のステップ
 

--- a/backend/app/api/v1/dialogue.py
+++ b/backend/app/api/v1/dialogue.py
@@ -45,12 +45,12 @@ def get_session_store() -> SessionStore:
 def get_llm_client() -> LLMClient | None:
     """LLMクライアントを取得する（依存性注入用）
 
-    環境変数からAPIキーを取得し、GeminiClientを生成します。
-    APIキーが設定されていない場合はNoneを返します。
+    環境変数からプロジェクトIDを取得し、Vertex AI経由でGeminiClientを生成します。
+    プロジェクトIDが設定されていない場合はNoneを返します（フォールバック動作）。
     """
-    api_key = os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
-    if api_key:
-        return GeminiClient(api_key=api_key)
+    project = os.environ.get("GOOGLE_CLOUD_PROJECT")
+    if project:
+        return GeminiClient(project=project)
     return None
 
 

--- a/backend/tests/unit/services/adk/dialogue/test_gemini_client.py
+++ b/backend/tests/unit/services/adk/dialogue/test_gemini_client.py
@@ -1,4 +1,4 @@
-"""GeminiClientのユニットテスト"""
+"""GeminiClientのユニットテスト（Vertex AI モード）"""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -11,18 +11,26 @@ from app.services.adk.dialogue.manager import LLMClient
 class TestGeminiClientProtocol:
     """GeminiClientがLLMClientプロトコルに準拠しているかテスト"""
 
-    def test_gemini_client_implements_protocol(self) -> None:
+    @patch("app.services.adk.dialogue.gemini_client.genai.Client")
+    def test_gemini_client_implements_protocol(
+        self,
+        mock_client: MagicMock,  # noqa: ARG002
+    ) -> None:
         """GeminiClientがLLMClientプロトコルを実装している"""
         # Arrange & Act
-        client = GeminiClient(api_key="test-api-key")
+        client = GeminiClient(project="test-project")
 
         # Assert
         assert isinstance(client, LLMClient)
 
-    def test_gemini_client_has_generate_method(self) -> None:
+    @patch("app.services.adk.dialogue.gemini_client.genai.Client")
+    def test_gemini_client_has_generate_method(
+        self,
+        mock_client: MagicMock,  # noqa: ARG002
+    ) -> None:
         """GeminiClientがgenerateメソッドを持っている"""
         # Arrange
-        client = GeminiClient(api_key="test-api-key")
+        client = GeminiClient(project="test-project")
 
         # Assert
         assert hasattr(client, "generate")
@@ -32,62 +40,101 @@ class TestGeminiClientProtocol:
 class TestGeminiClientInit:
     """GeminiClientの初期化テスト"""
 
-    def test_init_with_api_key(self) -> None:
-        """APIキーを指定して初期化できる"""
+    @patch("app.services.adk.dialogue.gemini_client.genai.Client")
+    def test_init_with_project(self, mock_client: MagicMock) -> None:
+        """プロジェクトIDを指定して初期化できる"""
         # Arrange & Act
-        client = GeminiClient(api_key="test-api-key")
+        client = GeminiClient(project="test-project")
 
         # Assert
-        assert client._api_key == "test-api-key"
+        assert client._project == "test-project"
+        mock_client.assert_called_once_with(
+            vertexai=True,
+            project="test-project",
+            location="us-central1",
+        )
 
-    def test_init_with_custom_model(self) -> None:
+    @patch("app.services.adk.dialogue.gemini_client.genai.Client")
+    def test_init_with_custom_location(self, mock_client: MagicMock) -> None:
+        """カスタムリージョンを指定して初期化できる"""
+        # Arrange & Act
+        client = GeminiClient(project="test-project", location="asia-northeast1")
+
+        # Assert
+        assert client._location == "asia-northeast1"
+        mock_client.assert_called_once_with(
+            vertexai=True,
+            project="test-project",
+            location="asia-northeast1",
+        )
+
+    @patch("app.services.adk.dialogue.gemini_client.genai.Client")
+    def test_init_with_custom_model(
+        self,
+        mock_client: MagicMock,  # noqa: ARG002
+    ) -> None:
         """カスタムモデルを指定して初期化できる"""
         # Arrange & Act
-        client = GeminiClient(api_key="test-api-key", model="gemini-2.5-pro")
+        client = GeminiClient(project="test-project", model="gemini-2.5-pro")
 
         # Assert
         assert client._model == "gemini-2.5-pro"
 
-    def test_init_with_default_model(self) -> None:
+    @patch("app.services.adk.dialogue.gemini_client.genai.Client")
+    def test_init_with_default_model(
+        self,
+        mock_client: MagicMock,  # noqa: ARG002
+    ) -> None:
         """デフォルトモデルが設定される"""
         # Arrange & Act
-        client = GeminiClient(api_key="test-api-key")
+        client = GeminiClient(project="test-project")
 
         # Assert
         assert client._model == GeminiClient.DEFAULT_MODEL
 
-    @patch.dict("os.environ", {"GOOGLE_API_KEY": "env-api-key"})
-    def test_init_from_env_google_api_key(self) -> None:
-        """GOOGLE_API_KEY環境変数から初期化できる"""
+    @patch("app.services.adk.dialogue.gemini_client.genai.Client")
+    def test_init_with_default_location(
+        self,
+        mock_client: MagicMock,  # noqa: ARG002
+    ) -> None:
+        """デフォルトリージョンが設定される"""
+        # Arrange & Act
+        client = GeminiClient(project="test-project")
+
+        # Assert
+        assert client._location == "us-central1"
+
+    @patch("app.services.adk.dialogue.gemini_client.genai.Client")
+    @patch.dict("os.environ", {"GOOGLE_CLOUD_PROJECT": "env-project"})
+    def test_init_from_env_project(
+        self,
+        mock_client: MagicMock,  # noqa: ARG002
+    ) -> None:
+        """GOOGLE_CLOUD_PROJECT環境変数から初期化できる"""
         # Arrange & Act
         client = GeminiClient()
 
         # Assert
-        assert client._api_key == "env-api-key"
+        assert client._project == "env-project"
 
-    @patch.dict("os.environ", {"GEMINI_API_KEY": "gemini-env-key"}, clear=True)
-    def test_init_from_env_gemini_api_key(self) -> None:
-        """GEMINI_API_KEY環境変数から初期化できる（後方互換性）"""
+    @patch("app.services.adk.dialogue.gemini_client.genai.Client")
+    @patch.dict("os.environ", {"GOOGLE_CLOUD_LOCATION": "asia-northeast1"})
+    def test_init_from_env_location(
+        self,
+        mock_client: MagicMock,  # noqa: ARG002
+    ) -> None:
+        """GOOGLE_CLOUD_LOCATION環境変数からリージョンを取得できる"""
         # Arrange & Act
-        client = GeminiClient()
+        client = GeminiClient(project="test-project")
 
         # Assert
-        assert client._api_key == "gemini-env-key"
-
-    @patch.dict("os.environ", {"GOOGLE_API_KEY": "google-key", "GEMINI_API_KEY": "gemini-key"})
-    def test_google_api_key_takes_precedence(self) -> None:
-        """GOOGLE_API_KEYがGEMINI_API_KEYより優先される"""
-        # Arrange & Act
-        client = GeminiClient()
-
-        # Assert
-        assert client._api_key == "google-key"
+        assert client._location == "asia-northeast1"
 
     @patch.dict("os.environ", {}, clear=True)
-    def test_init_without_api_key_raises_error(self) -> None:
-        """APIキーなしで初期化するとエラー"""
+    def test_init_without_project_raises_error(self) -> None:
+        """プロジェクトIDなしで初期化するとエラー"""
         # Arrange & Act & Assert
-        with pytest.raises(ValueError, match="API key is required"):
+        with pytest.raises(ValueError, match="Google Cloud project is required"):
             GeminiClient()
 
 
@@ -95,99 +142,104 @@ class TestGeminiClientGenerate:
     """GeminiClientのgenerate()メソッドテスト"""
 
     @pytest.mark.asyncio
-    async def test_generate_returns_text(self) -> None:
+    @patch("app.services.adk.dialogue.gemini_client.genai.Client")
+    async def test_generate_returns_text(self, mock_client_class: MagicMock) -> None:
         """generate()がテキストを返す"""
         # Arrange
-        client = GeminiClient(api_key="test-api-key")
-
         mock_response = MagicMock()
         mock_response.text = "Generated response"
 
-        mock_genai_client = MagicMock()
-        mock_genai_client.aio.models.generate_content = AsyncMock(return_value=mock_response)
+        mock_client_instance = MagicMock()
+        mock_client_instance.aio.models.generate_content = AsyncMock(return_value=mock_response)
+        mock_client_class.return_value = mock_client_instance
 
-        with patch.object(client, "_client", mock_genai_client):
-            # Act
-            result = await client.generate("Test prompt")
+        client = GeminiClient(project="test-project")
 
-            # Assert
-            assert result == "Generated response"
+        # Act
+        result = await client.generate("Test prompt")
+
+        # Assert
+        assert result == "Generated response"
 
     @pytest.mark.asyncio
-    async def test_generate_calls_api_with_correct_params(self) -> None:
+    @patch("app.services.adk.dialogue.gemini_client.genai.Client")
+    async def test_generate_calls_api_with_correct_params(
+        self, mock_client_class: MagicMock
+    ) -> None:
         """generate()が正しいパラメータでAPIを呼び出す"""
         # Arrange
-        client = GeminiClient(api_key="test-api-key", model="gemini-2.5-flash")
-
         mock_response = MagicMock()
         mock_response.text = "Response"
 
-        mock_genai_client = MagicMock()
-        mock_genai_client.aio.models.generate_content = AsyncMock(return_value=mock_response)
+        mock_client_instance = MagicMock()
+        mock_client_instance.aio.models.generate_content = AsyncMock(return_value=mock_response)
+        mock_client_class.return_value = mock_client_instance
 
-        with patch.object(client, "_client", mock_genai_client):
-            # Act
-            await client.generate("Test prompt")
+        client = GeminiClient(project="test-project", model="gemini-2.5-flash")
 
-            # Assert
-            mock_genai_client.aio.models.generate_content.assert_called_once()
-            call_kwargs = mock_genai_client.aio.models.generate_content.call_args.kwargs
-            assert call_kwargs["model"] == "gemini-2.5-flash"
-            assert call_kwargs["contents"] == "Test prompt"
+        # Act
+        await client.generate("Test prompt")
+
+        # Assert
+        mock_client_instance.aio.models.generate_content.assert_called_once()
+        call_kwargs = mock_client_instance.aio.models.generate_content.call_args.kwargs
+        assert call_kwargs["model"] == "gemini-2.5-flash"
+        assert call_kwargs["contents"] == "Test prompt"
 
     @pytest.mark.asyncio
-    async def test_generate_with_system_instruction(self) -> None:
+    @patch("app.services.adk.dialogue.gemini_client.genai.Client")
+    async def test_generate_with_system_instruction(self, mock_client_class: MagicMock) -> None:
         """システム指示付きでgenerate()が動作する"""
         # Arrange
-        system_instruction = "You are a helpful assistant."
-        client = GeminiClient(api_key="test-api-key", system_instruction=system_instruction)
-
         mock_response = MagicMock()
         mock_response.text = "Response with system instruction"
 
-        mock_genai_client = MagicMock()
-        mock_genai_client.aio.models.generate_content = AsyncMock(return_value=mock_response)
+        mock_client_instance = MagicMock()
+        mock_client_instance.aio.models.generate_content = AsyncMock(return_value=mock_response)
+        mock_client_class.return_value = mock_client_instance
 
-        with patch.object(client, "_client", mock_genai_client):
-            # Act
-            result = await client.generate("Test prompt")
+        system_instruction = "You are a helpful assistant."
+        client = GeminiClient(project="test-project", system_instruction=system_instruction)
 
-            # Assert
-            assert result == "Response with system instruction"
-            call_kwargs = mock_genai_client.aio.models.generate_content.call_args.kwargs
-            assert "config" in call_kwargs
+        # Act
+        result = await client.generate("Test prompt")
+
+        # Assert
+        assert result == "Response with system instruction"
+        call_kwargs = mock_client_instance.aio.models.generate_content.call_args.kwargs
+        assert "config" in call_kwargs
 
     @pytest.mark.asyncio
-    async def test_generate_handles_api_error(self) -> None:
+    @patch("app.services.adk.dialogue.gemini_client.genai.Client")
+    async def test_generate_handles_api_error(self, mock_client_class: MagicMock) -> None:
         """APIエラー時に適切な例外を発生させる"""
         # Arrange
-        client = GeminiClient(api_key="test-api-key")
-
-        mock_genai_client = MagicMock()
-        mock_genai_client.aio.models.generate_content = AsyncMock(
+        mock_client_instance = MagicMock()
+        mock_client_instance.aio.models.generate_content = AsyncMock(
             side_effect=Exception("API Error")
         )
+        mock_client_class.return_value = mock_client_instance
 
-        with (
-            patch.object(client, "_client", mock_genai_client),
-            pytest.raises(RuntimeError, match="LLM generation failed"),
-        ):
+        client = GeminiClient(project="test-project")
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match="LLM generation failed"):
             await client.generate("Test prompt")
 
     @pytest.mark.asyncio
-    async def test_generate_handles_empty_response(self) -> None:
+    @patch("app.services.adk.dialogue.gemini_client.genai.Client")
+    async def test_generate_handles_empty_response(self, mock_client_class: MagicMock) -> None:
         """空の応答時にエラーを発生させる"""
         # Arrange
-        client = GeminiClient(api_key="test-api-key")
-
         mock_response = MagicMock()
         mock_response.text = None
 
-        mock_genai_client = MagicMock()
-        mock_genai_client.aio.models.generate_content = AsyncMock(return_value=mock_response)
+        mock_client_instance = MagicMock()
+        mock_client_instance.aio.models.generate_content = AsyncMock(return_value=mock_response)
+        mock_client_class.return_value = mock_client_instance
 
-        with (
-            patch.object(client, "_client", mock_genai_client),
-            pytest.raises(RuntimeError, match="Empty response"),
-        ):
+        client = GeminiClient(project="test-project")
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match="Empty response"):
             await client.generate("Test prompt")


### PR DESCRIPTION
## Summary

- 開発環境と本番環境の認証方式を Vertex AI (Application Default Credentials) に統一
- API Key ベースの認証を廃止し、`GOOGLE_CLOUD_PROJECT` 環境変数を使用
- コードパスの分岐を排除し、環境間の差異によるバグリスクを低減

## Changes

| ファイル | 変更内容 |
|----------|----------|
| `gemini_client.py` | `project`/`location` パラメータ追加、API Key 関連削除 |
| `dialogue.py` | `get_llm_client()` を Vertex AI モードに変更 |
| `test_gemini_client.py` | Vertex AI モード用テストに更新（15件） |
| `CLAUDE.md` | ローカル開発セットアップ手順を追加 |

## Environment Variables

| 変数名 | 必須 | 説明 |
|--------|------|------|
| `GOOGLE_CLOUD_PROJECT` | ✅ | GCPプロジェクトID |
| `GOOGLE_CLOUD_LOCATION` | ❌ | リージョン（デフォルト: us-central1） |

## Local Development Setup

```bash
# 1. 認証情報を設定（初回のみ）
gcloud auth application-default login

# 2. プロジェクトIDを設定
export GOOGLE_CLOUD_PROJECT=your-project-id

# 3. バックエンドを起動
cd backend && uv run uvicorn app.main:app --reload
```

## Test plan

- [x] `uv run ruff check app tests` - エラーなし
- [x] `uv run mypy app/` - エラーなし
- [x] `uv run pytest tests/ -v` - 202件パス
- [x] カバレッジ 98%

🤖 Generated with [Claude Code](https://claude.com/claude-code)