### PR TITLE
chore(git): add Terraform files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,10 @@ htmlcov/
 *.p12
 *-service-account.json
 firebase-adminsdk-*.json
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example


### PR DESCRIPTION
## Summary

- Add Terraform-related entries to `.gitignore` to prevent committing:
  - `.terraform/` (provider binaries and module cache)
  - `*.tfstate` and `*.tfstate.*` (state files)
  - `*.tfvars` (variable files, except examples)

## Test plan

- [x] Verify `.terraform/` directory is no longer shown as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)