### PR TITLE
fix(backend): add production frontend URL to CORS origins

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,7 @@
 """宿題コーチロボット - バックエンドAPIエントリーポイント"""
 
+import os
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -15,9 +17,19 @@ app = FastAPI(
 app.include_router(api_v1_router)
 
 # CORS設定
+# 環境変数CORS_ORIGINSで追加のオリジンを指定可能（カンマ区切り）
+cors_origins = [
+    "http://localhost:3000",  # ローカル開発
+    "https://homework-coach-frontend-652907685934.asia-northeast1.run.app",  # 本番
+]
+# 環境変数から追加のオリジンを取得
+extra_origins = os.environ.get("CORS_ORIGINS", "")
+if extra_origins:
+    cors_origins.extend(origin.strip() for origin in extra_origins.split(",") if origin.strip())
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],  # フロントエンド開発サーバー
+    allow_origins=cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary

- Add Cloud Run frontend URL to CORS allowed origins
- Support additional origins via `CORS_ORIGINS` environment variable

## Problem

CORS error when accessing backend from production frontend:
```
Access to fetch at 'https://homework-coach-backend-...run.app/api/v1/dialogue/sessions' 
from origin 'https://homework-coach-frontend-...run.app' has been blocked by CORS policy
```

## Solution

Update `backend/app/main.py` to include production frontend URL in CORS origins.

## Test plan

- [x] Backend lint passes
- [x] Backend typecheck passes
- [x] Docker image rebuilt and deployed
- [x] CORS preflight request returns correct headers

```bash
curl -I -X OPTIONS \
  -H "Origin: https://homework-coach-frontend-652907685934.asia-northeast1.run.app" \
  -H "Access-Control-Request-Method: POST" \
  https://homework-coach-backend-652907685934.asia-northeast1.run.app/api/v1/dialogue/sessions

# Response includes:
# access-control-allow-origin: https://homework-coach-frontend-652907685934.asia-northeast1.run.app
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)