### PR TITLE
feat(frontend): enable voice input

### DIFF
--- a/frontend/src/app/session/SessionContent.tsx
+++ b/frontend/src/app/session/SessionContent.tsx
@@ -38,8 +38,8 @@ export function SessionContent({ characterType }: SessionContentProps) {
 	const [characterState] = useAtom(characterStateAtom)
 	const [learningProgress] = useAtom(learningProgressAtom)
 
-	// 音声入力の有効化状態（MVP期間は無効）
-	const [isVoiceEnabled] = useState(false)
+	// 音声入力の有効化状態
+	const [isVoiceEnabled] = useState(true)
 
 	// セッション管理フック
 	const {


### PR DESCRIPTION
## Summary
- フロントエンドの音声入力機能を有効化
- `isVoiceEnabled` ステートを `true` に変更
- Cloud Runにデプロイ済み

## Test plan
- [ ] 本番環境で音声入力ボタンが有効になっていることを確認
- [ ] 録音ボタンをクリックして音声入力が開始されることを確認
- [ ] WebSocket接続が確立されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)