### PR TITLE
feat(frontend): integrate WebSocket voice streaming

### DIFF
--- a/frontend/lib/hooks/index.ts
+++ b/frontend/lib/hooks/index.ts
@@ -3,6 +3,8 @@
 export { useAudioPlayer } from "./useAudioPlayer"
 export type { UseDialogueOptions, UseDialogueReturn } from "./useDialogue"
 export { useDialogue } from "./useDialogue"
+export type { UsePcmPlayerReturn } from "./usePcmPlayer"
+export { usePcmPlayer } from "./usePcmPlayer"
 export type { UseSessionOptions, UseSessionReturn } from "./useSession"
 export { useSession } from "./useSession"
 export { useVoiceRecorder } from "./useVoiceRecorder"

--- a/frontend/lib/hooks/usePcmPlayer.test.ts
+++ b/frontend/lib/hooks/usePcmPlayer.test.ts
@@ -1,0 +1,285 @@
+/**
+ * usePcmPlayer フックテスト
+ *
+ * AudioWorkletベースのPCMストリーミング再生フックのテスト
+ */
+
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { usePcmPlayer } from "./usePcmPlayer"
+
+// AudioWorkletNode モック
+const mockWorkletPort = {
+	postMessage: vi.fn(),
+	onmessage: null as ((event: MessageEvent) => void) | null,
+}
+
+const mockWorkletNodeConnect = vi.fn()
+const mockWorkletNodeDisconnect = vi.fn()
+
+class MockAudioWorkletNode {
+	port = {
+		postMessage: mockWorkletPort.postMessage,
+		onmessage: mockWorkletPort.onmessage,
+	}
+	connect = mockWorkletNodeConnect
+	disconnect = mockWorkletNodeDisconnect
+}
+
+// AudioContext モック
+const mockAddModule = vi.fn().mockResolvedValue(undefined)
+const mockClose = vi.fn().mockResolvedValue(undefined)
+
+class MockAudioContext {
+	sampleRate = 24000
+	state = "running"
+	audioWorklet = {
+		addModule: mockAddModule,
+	}
+	destination = {}
+	close = mockClose
+}
+
+globalThis.AudioContext = MockAudioContext as unknown as typeof AudioContext
+globalThis.AudioWorkletNode = MockAudioWorkletNode as unknown as typeof AudioWorkletNode
+
+describe("usePcmPlayer", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		vi.restoreAllMocks()
+	})
+
+	describe("初期状態", () => {
+		it("isPlayingがfalseで初期化される", () => {
+			const { result } = renderHook(() => usePcmPlayer())
+			expect(result.current.isPlaying).toBe(false)
+		})
+
+		it("必要な関数が返される", () => {
+			const { result } = renderHook(() => usePcmPlayer())
+			expect(typeof result.current.feedAudio).toBe("function")
+			expect(typeof result.current.stop).toBe("function")
+			expect(typeof result.current.initialize).toBe("function")
+			expect(typeof result.current.cleanup).toBe("function")
+		})
+	})
+
+	describe("initialize", () => {
+		it("AudioContextとWorkletNodeを作成する", async () => {
+			const { result } = renderHook(() => usePcmPlayer())
+
+			await act(async () => {
+				await result.current.initialize()
+			})
+
+			expect(mockAddModule).toHaveBeenCalledWith("/worklets/pcm-player-processor.js")
+			expect(mockWorkletNodeConnect).toHaveBeenCalled()
+		})
+
+		it("二重初期化しない", async () => {
+			const { result } = renderHook(() => usePcmPlayer())
+
+			await act(async () => {
+				await result.current.initialize()
+			})
+			await act(async () => {
+				await result.current.initialize()
+			})
+
+			// addModuleは1回のみ呼ばれる
+			expect(mockAddModule).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	describe("feedAudio", () => {
+		it("初期化後にworklet portへデータを送信する", async () => {
+			const { result } = renderHook(() => usePcmPlayer())
+
+			await act(async () => {
+				await result.current.initialize()
+			})
+
+			const pcmData = new ArrayBuffer(1024)
+
+			act(() => {
+				result.current.feedAudio(pcmData)
+			})
+
+			expect(mockWorkletPort.postMessage).toHaveBeenCalledWith(pcmData)
+		})
+
+		it("feedAudio後にisPlayingがtrueになる", async () => {
+			const { result } = renderHook(() => usePcmPlayer())
+
+			await act(async () => {
+				await result.current.initialize()
+			})
+
+			act(() => {
+				result.current.feedAudio(new ArrayBuffer(1024))
+			})
+
+			expect(result.current.isPlaying).toBe(true)
+		})
+
+		it("300ms後にisPlayingがfalseになる", async () => {
+			const { result } = renderHook(() => usePcmPlayer())
+
+			await act(async () => {
+				await result.current.initialize()
+			})
+
+			act(() => {
+				result.current.feedAudio(new ArrayBuffer(1024))
+			})
+
+			expect(result.current.isPlaying).toBe(true)
+
+			act(() => {
+				vi.advanceTimersByTime(300)
+			})
+
+			expect(result.current.isPlaying).toBe(false)
+		})
+
+		it("連続feedAudioでタイムアウトがリセットされる", async () => {
+			const { result } = renderHook(() => usePcmPlayer())
+
+			await act(async () => {
+				await result.current.initialize()
+			})
+
+			act(() => {
+				result.current.feedAudio(new ArrayBuffer(1024))
+			})
+
+			// 200ms後に再度feed
+			act(() => {
+				vi.advanceTimersByTime(200)
+			})
+
+			act(() => {
+				result.current.feedAudio(new ArrayBuffer(1024))
+			})
+
+			// 最初のfeedから300ms経過してもまだplaying
+			act(() => {
+				vi.advanceTimersByTime(200)
+			})
+
+			expect(result.current.isPlaying).toBe(true)
+
+			// 2回目のfeedから300ms経過でfalse
+			act(() => {
+				vi.advanceTimersByTime(100)
+			})
+
+			expect(result.current.isPlaying).toBe(false)
+		})
+
+		it("初期化前はpostMessageを呼ばない", () => {
+			const { result } = renderHook(() => usePcmPlayer())
+
+			act(() => {
+				result.current.feedAudio(new ArrayBuffer(1024))
+			})
+
+			expect(mockWorkletPort.postMessage).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("stop", () => {
+		it("endOfAudioコマンドを送信する", async () => {
+			const { result } = renderHook(() => usePcmPlayer())
+
+			await act(async () => {
+				await result.current.initialize()
+			})
+
+			act(() => {
+				result.current.feedAudio(new ArrayBuffer(1024))
+			})
+
+			act(() => {
+				result.current.stop()
+			})
+
+			expect(mockWorkletPort.postMessage).toHaveBeenCalledWith({ command: "endOfAudio" })
+		})
+
+		it("isPlayingをfalseにする", async () => {
+			const { result } = renderHook(() => usePcmPlayer())
+
+			await act(async () => {
+				await result.current.initialize()
+			})
+
+			act(() => {
+				result.current.feedAudio(new ArrayBuffer(1024))
+			})
+
+			expect(result.current.isPlaying).toBe(true)
+
+			act(() => {
+				result.current.stop()
+			})
+
+			expect(result.current.isPlaying).toBe(false)
+		})
+	})
+
+	describe("cleanup", () => {
+		it("AudioContextを閉じる", async () => {
+			const { result } = renderHook(() => usePcmPlayer())
+
+			await act(async () => {
+				await result.current.initialize()
+			})
+
+			act(() => {
+				result.current.cleanup()
+			})
+
+			expect(mockClose).toHaveBeenCalled()
+		})
+
+		it("WorkletNodeを切断する", async () => {
+			const { result } = renderHook(() => usePcmPlayer())
+
+			await act(async () => {
+				await result.current.initialize()
+			})
+
+			act(() => {
+				result.current.cleanup()
+			})
+
+			expect(mockWorkletNodeDisconnect).toHaveBeenCalled()
+		})
+
+		it("cleanup後にfeedAudioが無視される", async () => {
+			const { result } = renderHook(() => usePcmPlayer())
+
+			await act(async () => {
+				await result.current.initialize()
+			})
+
+			act(() => {
+				result.current.cleanup()
+			})
+
+			mockWorkletPort.postMessage.mockClear()
+
+			act(() => {
+				result.current.feedAudio(new ArrayBuffer(1024))
+			})
+
+			expect(mockWorkletPort.postMessage).not.toHaveBeenCalled()
+		})
+	})
+})

--- a/frontend/lib/hooks/usePcmPlayer.ts
+++ b/frontend/lib/hooks/usePcmPlayer.ts
@@ -1,0 +1,115 @@
+/**
+ * usePcmPlayer フック
+ *
+ * AudioWorkletベースのPCMストリーミング再生フック。
+ * Gemini Live APIからのPCM 16-bit音声データを24kHzで再生する。
+ */
+
+import { useCallback, useRef, useState } from "react"
+
+/** フックの戻り値 */
+export interface UsePcmPlayerReturn {
+	/** 再生中フラグ */
+	isPlaying: boolean
+	/** PCMデータを再生バッファに追加 */
+	feedAudio: (pcmData: ArrayBuffer) => void
+	/** 再生を停止しバッファをクリア */
+	stop: () => void
+	/** AudioContextとWorkletを初期化 */
+	initialize: () => Promise<void>
+	/** リソースを解放 */
+	cleanup: () => void
+}
+
+/** 再生停止判定のタイムアウト（ms） */
+const PLAYBACK_TIMEOUT_MS = 300
+
+/**
+ * PCMストリーミング再生フック
+ *
+ * AudioContext(24kHz) + pcm-player-processor.js AudioWorkletを使用して
+ * ストリーミングPCMデータをリアルタイム再生する。
+ */
+export function usePcmPlayer(): UsePcmPlayerReturn {
+	const [isPlaying, setIsPlaying] = useState(false)
+
+	const audioContextRef = useRef<AudioContext | null>(null)
+	const workletNodeRef = useRef<AudioWorkletNode | null>(null)
+	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+	const initialize = useCallback(async () => {
+		// 二重初期化を防止
+		if (audioContextRef.current) {
+			return
+		}
+
+		const audioContext = new AudioContext({ sampleRate: 24000 })
+		audioContextRef.current = audioContext
+
+		await audioContext.audioWorklet.addModule("/worklets/pcm-player-processor.js")
+
+		const workletNode = new AudioWorkletNode(audioContext, "pcm-player-processor")
+		workletNode.connect(audioContext.destination)
+		workletNodeRef.current = workletNode
+	}, [])
+
+	const feedAudio = useCallback((pcmData: ArrayBuffer) => {
+		if (!workletNodeRef.current) {
+			return
+		}
+
+		workletNodeRef.current.port.postMessage(pcmData)
+		setIsPlaying(true)
+
+		// 既存のタイムアウトをクリア
+		if (timeoutRef.current) {
+			clearTimeout(timeoutRef.current)
+		}
+
+		// 300ms間データが来なければ再生停止と判定
+		timeoutRef.current = setTimeout(() => {
+			setIsPlaying(false)
+			timeoutRef.current = null
+		}, PLAYBACK_TIMEOUT_MS)
+	}, [])
+
+	const stop = useCallback(() => {
+		if (timeoutRef.current) {
+			clearTimeout(timeoutRef.current)
+			timeoutRef.current = null
+		}
+
+		if (workletNodeRef.current) {
+			workletNodeRef.current.port.postMessage({ command: "endOfAudio" })
+		}
+
+		setIsPlaying(false)
+	}, [])
+
+	const cleanup = useCallback(() => {
+		if (timeoutRef.current) {
+			clearTimeout(timeoutRef.current)
+			timeoutRef.current = null
+		}
+
+		if (workletNodeRef.current) {
+			workletNodeRef.current.disconnect()
+			workletNodeRef.current = null
+		}
+
+		if (audioContextRef.current) {
+			audioContextRef.current.close()
+			audioContextRef.current = null
+		}
+
+		setIsPlaying(false)
+	}, [])
+
+	return {
+		isPlaying,
+		feedAudio,
+		stop,
+		initialize,
+		cleanup,
+	}
+}

--- a/frontend/lib/hooks/useVoiceStream.test.tsx
+++ b/frontend/lib/hooks/useVoiceStream.test.tsx
@@ -279,6 +279,63 @@ describe("useVoiceStream", () => {
 		})
 	})
 
+	describe("audioLevel", () => {
+		it("初期値が0である", () => {
+			const { TestWrapper } = createTestWrapper()
+			const { result } = renderHook(() => useVoiceStream(), { wrapper: TestWrapper })
+
+			expect(result.current.audioLevel).toBe(0)
+		})
+
+		it("録音開始時はaudioLevelが0のまま（データ受信前）", async () => {
+			const { TestWrapper } = createTestWrapper()
+			const { result } = renderHook(() => useVoiceStream(), { wrapper: TestWrapper })
+
+			// 接続
+			act(() => {
+				result.current.connect("user-1", "session-1")
+			})
+			act(() => {
+				getMockClientOptions()?.onConnectionChange("connected")
+				setMockIsConnected(true)
+			})
+
+			// 録音開始
+			await act(async () => {
+				await result.current.startRecording()
+			})
+
+			// workletからデータ受信前はaudioLevelは0
+			expect(result.current.audioLevel).toBe(0)
+		})
+
+		it("録音停止でaudioLevelが0にリセットされる", async () => {
+			const { TestWrapper } = createTestWrapper()
+			const { result } = renderHook(() => useVoiceStream(), { wrapper: TestWrapper })
+
+			// 接続
+			act(() => {
+				result.current.connect("user-1", "session-1")
+			})
+			act(() => {
+				getMockClientOptions()?.onConnectionChange("connected")
+				setMockIsConnected(true)
+			})
+
+			// 録音開始
+			await act(async () => {
+				await result.current.startRecording()
+			})
+
+			// 録音停止
+			act(() => {
+				result.current.stopRecording()
+			})
+
+			expect(result.current.audioLevel).toBe(0)
+		})
+	})
+
 	describe("エラーハンドリング", () => {
 		it("エラーがerror状態に反映される", () => {
 			const { TestWrapper } = createTestWrapper()

--- a/frontend/src/app/session/SessionContent.test.tsx
+++ b/frontend/src/app/session/SessionContent.test.tsx
@@ -35,6 +35,7 @@ vi.mock("@/lib/hooks/useVoiceStream", () => ({
 	useVoiceStream: () => ({
 		connectionState: "disconnected",
 		isRecording: false,
+		audioLevel: 0,
 		error: null,
 		connect: vi.fn(),
 		disconnect: vi.fn(),
@@ -42,6 +43,17 @@ vi.mock("@/lib/hooks/useVoiceStream", () => ({
 		stopRecording: vi.fn(),
 		sendText: vi.fn(),
 		clearError: vi.fn(),
+	}),
+}))
+
+// usePcmPlayerをモック
+vi.mock("@/lib/hooks/usePcmPlayer", () => ({
+	usePcmPlayer: () => ({
+		isPlaying: false,
+		feedAudio: vi.fn(),
+		stop: vi.fn(),
+		initialize: vi.fn().mockResolvedValue(undefined),
+		cleanup: vi.fn(),
 	}),
 }))
 


### PR DESCRIPTION
## Summary
- Add `usePcmPlayer` hook for AudioWorklet-based PCM streaming playback (24kHz)
- Add `audioLevel` (RMS calculation) to `useVoiceStream` for real-time voice level visualization
- Integrate WebSocket callbacks into `SessionContent`: PCM playback, transcription handling, character state transitions (listening/thinking/speaking/idle)

## Changes
| File | Action | Description |
|------|--------|-------------|
| `lib/hooks/usePcmPlayer.ts` | NEW | AudioWorklet PCM playback hook |
| `lib/hooks/usePcmPlayer.test.ts` | NEW | 14 tests for usePcmPlayer |
| `lib/hooks/useVoiceStream.ts` | MODIFY | audioLevel (RMS) 追加 |
| `lib/hooks/useVoiceStream.test.tsx` | MODIFY | audioLevel テスト3件追加 |
| `lib/hooks/index.ts` | MODIFY | usePcmPlayer エクスポート追加 |
| `src/app/session/SessionContent.tsx` | MODIFY | WebSocket統合（コールバック・再生・状態遷移） |
| `src/app/session/SessionContent.test.tsx` | MODIFY | usePcmPlayer モック追加 |
| `tests/pages/Session.test.tsx` | MODIFY | WebSocket音声統合テスト5件追加 |

## Test plan
- [x] `bun lint` - Biome lint clean (89 files)
- [x] `bun typecheck` - TypeScript type check clean
- [x] `bun run test -- --run` - 194/194 tests passed (23 files)
- [ ] E2E動作確認はバックエンドWebSocketエンドポイント完了後

🤖 Generated with [Claude Code](https://claude.com/claude-code)