### PR TITLE
fix(frontend): improve text input visibility

### DIFF
--- a/frontend/components/ui/TextInput/TextInput.tsx
+++ b/frontend/components/ui/TextInput/TextInput.tsx
@@ -61,8 +61,8 @@ export function TextInput({
 				placeholder={placeholder}
 				aria-label="メッセージ入力"
 				className={`
-					flex-1 rounded-xl border-2 border-gray-200 px-4 py-3
-					text-lg transition-colors
+					flex-1 rounded-xl border-2 border-gray-200 bg-white px-4 py-3
+					text-lg text-gray-900 transition-colors
 					placeholder:text-gray-400
 					focus:border-blue-400 focus:outline-none
 					disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500


### PR DESCRIPTION
## Summary
- TextInput コンポーネントに `bg-white` と `text-gray-900` を追加し、背景グラデーション上でのテキスト視認性を改善

## Test plan
- [x] TextInput の既存テスト 15件が全てパス
- [ ] ブラウザでセッションページを開き、テキスト入力欄の文字がはっきり見えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)