### PR TITLE
feat(infra): Add GitHub Actions WIF Terraform module

### DIFF
--- a/.steering/20260207-github-wif-terraform/design.md
+++ b/.steering/20260207-github-wif-terraform/design.md
@@ -1,0 +1,48 @@
+# Design - GitHub Actions WIF Terraform Module
+
+## アーキテクチャ概要
+
+新規モジュール `modules/github_wif/` を作成し、GitHub Actions ↔ GCP 間の Workload Identity Federation を管理する。
+
+```
+modules/github_wif/
+├── main.tf        # リソース定義
+├── variables.tf   # 入力変数
+└── outputs.tf     # 出力値
+```
+
+## リソース構成
+
+```
+google_service_account.github_actions
+├── google_project_iam_member.github_actions_artifact_registry  (artifactregistry.writer)
+├── google_project_iam_member.github_actions_run_admin          (run.admin)
+└── google_project_iam_member.github_actions_sa_user            (iam.serviceAccountUser)
+
+google_iam_workload_identity_pool.github_pool
+└── google_iam_workload_identity_pool_provider.github_provider  (OIDC)
+
+google_service_account_iam_member.github_actions_wif  (SA ↔ Pool binding)
+```
+
+## 既存ファイル修正
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `environments/dev/main.tf` | `module "github_wif"` 追加、API 2つ追加 |
+| `environments/dev/variables.tf` | `github_owner`, `github_repo` 追加 |
+| `environments/dev/outputs.tf` | WIF provider, SA email 出力追加 |
+| `bootstrap/main.tf` | `iamcredentials.googleapis.com` 追加 |
+
+## セキュリティ考慮事項
+
+- WIF プロバイダの attribute condition で `arakitakashi` オーナーのリポジトリに限定
+- 最小権限の原則: デプロイに必要な3ロールのみ付与
+
+## 代替案と採用理由
+
+| 案 | 判断 | 理由 |
+|----|------|------|
+| 既存 `modules/iam/` に追加 | ❌ 不採用 | IAMモジュールは Cloud Run SA 専用、責務が異なる |
+| 新規 `modules/github_wif/` | ✅ 採用 | ライフサイクル独立、既存パターンに合致 |
+| gcloud CLI で手動作成 | ❌ 不採用 | IaC 管理外になる |

--- a/.steering/20260207-github-wif-terraform/requirements.md
+++ b/.steering/20260207-github-wif-terraform/requirements.md
@@ -1,0 +1,45 @@
+# Requirements - GitHub Actions WIF Terraform Module
+
+## 背景・目的
+
+GitHub Actions の CI/CD で使用する Workload Identity Federation (WIF) リソースが GCP に存在しないため認証エラーが発生している。セットアップ手順書（gcloud CLI）は `.steering/20260206-github-actions-cicd/gcp-wif-setup.md` に存在するが未実行。手動作成ではなく Terraform で IaC 管理する。
+
+## 要求事項
+
+### 機能要件
+
+1. GitHub Actions から GCP への keyless 認証を可能にする WIF リソースを Terraform で作成
+2. 必要なリソース:
+   - Service Account (`github-actions`)
+   - Workload Identity Pool (`github-pool`)
+   - Workload Identity Provider (`github-provider`, OIDC)
+   - SA ↔ Pool のバインド
+   - IAM ロール付与（artifactregistry.writer, run.admin, iam.serviceAccountUser）
+
+### 非機能要件
+
+- 既存の Terraform モジュールパターンに合致すること
+- `terraform plan` で差分が WIF リソース作成のみであること
+
+### 制約条件
+
+- 既存 `modules/iam/` には追加しない（責務分離）
+- OIDC issuer: `https://token.actions.githubusercontent.com`
+- リポジトリオーナー制限: `arakitakashi`
+
+## 対象範囲
+
+### In Scope
+
+- `modules/github_wif/` モジュール新規作成
+- `environments/dev/` からのモジュール呼び出し
+- `bootstrap/main.tf` への API 追加
+
+### Out of Scope
+
+- GitHub Secrets の自動設定（手動で設定）
+- CD ワークフローの修正
+
+## 成功基準
+
+- `terraform apply` 後、GitHub Actions ワークフローで認証が成功すること

--- a/.steering/20260207-github-wif-terraform/tasklist.md
+++ b/.steering/20260207-github-wif-terraform/tasklist.md
@@ -1,0 +1,20 @@
+# Task List - GitHub Actions WIF Terraform Module
+
+## Phase 1: モジュール作成
+
+- [x] `modules/github_wif/main.tf` 作成
+- [x] `modules/github_wif/variables.tf` 作成
+- [x] `modules/github_wif/outputs.tf` 作成
+
+## Phase 2: 既存ファイル修正
+
+- [x] `bootstrap/main.tf` に `iamcredentials.googleapis.com` 追加
+- [x] `environments/dev/main.tf` に module 呼び出し + API 追加
+- [x] `environments/dev/variables.tf` に変数追加
+- [x] `environments/dev/outputs.tf` に出力追加
+
+## Phase 3: 検証
+
+- [x] `terraform fmt` でフォーマット確認
+- [x] `terraform validate` で構文確認
+- [ ] コミット

--- a/infrastructure/terraform/bootstrap/main.tf
+++ b/infrastructure/terraform/bootstrap/main.tf
@@ -75,17 +75,18 @@ resource "google_storage_bucket" "terraform_state" {
 
 locals {
   required_apis = [
-    "compute.googleapis.com",           # VPC, Firewall
-    "run.googleapis.com",               # Cloud Run
-    "artifactregistry.googleapis.com",  # Container Registry
-    "firestore.googleapis.com",         # Firestore Database
-    "bigquery.googleapis.com",          # BigQuery
-    "redis.googleapis.com",             # Memorystore for Redis
-    "secretmanager.googleapis.com",     # Secret Manager
-    "cloudbuild.googleapis.com",        # Cloud Build
-    "servicenetworking.googleapis.com", # VPC Peering for Redis
-    "vpcaccess.googleapis.com",         # VPC Access Connector
-    "iam.googleapis.com",               # IAM
+    "compute.googleapis.com",              # VPC, Firewall
+    "run.googleapis.com",                  # Cloud Run
+    "artifactregistry.googleapis.com",     # Container Registry
+    "firestore.googleapis.com",            # Firestore Database
+    "bigquery.googleapis.com",             # BigQuery
+    "redis.googleapis.com",                # Memorystore for Redis
+    "secretmanager.googleapis.com",        # Secret Manager
+    "cloudbuild.googleapis.com",           # Cloud Build
+    "servicenetworking.googleapis.com",    # VPC Peering for Redis
+    "vpcaccess.googleapis.com",            # VPC Access Connector
+    "iam.googleapis.com",                  # IAM
+    "iamcredentials.googleapis.com",       # IAM Credentials (for WIF)
     "cloudresourcemanager.googleapis.com", # Resource Manager
   ]
 }

--- a/infrastructure/terraform/environments/dev/main.tf
+++ b/infrastructure/terraform/environments/dev/main.tf
@@ -49,6 +49,8 @@ resource "google_project_service" "required_apis" {
     "texttospeech.googleapis.com",
     "vision.googleapis.com",
     "aiplatform.googleapis.com",
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
   ])
 
   project            = var.project_id
@@ -159,4 +161,15 @@ module "cloud_run" {
   allow_unauthenticated_backend = true
 
   depends_on = [module.vpc, module.iam, module.secret_manager]
+}
+
+# GitHub Actions Workload Identity Federation Module
+module "github_wif" {
+  source = "../../modules/github_wif"
+
+  project_id   = var.project_id
+  github_owner = var.github_owner
+  github_repo  = var.github_repo
+
+  depends_on = [google_project_service.required_apis]
 }

--- a/infrastructure/terraform/environments/dev/outputs.tf
+++ b/infrastructure/terraform/environments/dev/outputs.tf
@@ -68,6 +68,17 @@ output "frontend_url" {
   value       = module.cloud_run.frontend_url
 }
 
+# GitHub Actions WIF
+output "github_wif_provider" {
+  description = "The Workload Identity Provider (for GitHub Secret GCP_WORKLOAD_IDENTITY_PROVIDER)"
+  value       = module.github_wif.workload_identity_provider
+}
+
+output "github_wif_service_account" {
+  description = "The GitHub Actions service account email (for GitHub Secret GCP_SERVICE_ACCOUNT)"
+  value       = module.github_wif.service_account_email
+}
+
 # Summary for easy reference
 output "summary" {
   description = "Summary of important resources"

--- a/infrastructure/terraform/environments/dev/variables.tf
+++ b/infrastructure/terraform/environments/dev/variables.tf
@@ -38,6 +38,18 @@ variable "frontend_min_instances" {
 
 # NOTE: Redis variables removed - session management handled by Vertex AI / ADK
 
+variable "github_owner" {
+  description = "GitHub repository owner for Workload Identity Federation"
+  type        = string
+  default     = "arakitakashi"
+}
+
+variable "github_repo" {
+  description = "GitHub repository name for Workload Identity Federation"
+  type        = string
+  default     = "homework-coach-robo"
+}
+
 variable "enable_cdn" {
   description = "Enable Cloud CDN (dev default: false)"
   type        = bool

--- a/infrastructure/terraform/modules/github_wif/main.tf
+++ b/infrastructure/terraform/modules/github_wif/main.tf
@@ -1,0 +1,84 @@
+# GitHub Actions Workload Identity Federation Module
+# Creates WIF resources for keyless authentication from GitHub Actions to GCP.
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+# =============================================================================
+# Service Account for GitHub Actions
+# =============================================================================
+
+resource "google_service_account" "github_actions" {
+  account_id   = "github-actions"
+  display_name = "GitHub Actions Service Account"
+  description  = "Service account for GitHub Actions CI/CD via Workload Identity Federation"
+  project      = var.project_id
+}
+
+# Artifact Registry Writer (for Docker push)
+resource "google_project_iam_member" "github_actions_artifact_registry" {
+  project = var.project_id
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:${google_service_account.github_actions.email}"
+}
+
+# Cloud Run Admin (for deployment)
+resource "google_project_iam_member" "github_actions_run_admin" {
+  project = var.project_id
+  role    = "roles/run.admin"
+  member  = "serviceAccount:${google_service_account.github_actions.email}"
+}
+
+# Service Account User (to act as Cloud Run service accounts)
+resource "google_project_iam_member" "github_actions_sa_user" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.github_actions.email}"
+}
+
+# =============================================================================
+# Workload Identity Pool
+# =============================================================================
+
+resource "google_iam_workload_identity_pool" "github_pool" {
+  project                   = var.project_id
+  workload_identity_pool_id = "github-pool"
+  display_name              = "GitHub Actions Pool"
+  description               = "Workload Identity Pool for GitHub Actions"
+}
+
+# =============================================================================
+# Workload Identity Provider (OIDC)
+# =============================================================================
+
+resource "google_iam_workload_identity_pool_provider" "github_provider" {
+  project                            = var.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github_pool.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-provider"
+  display_name                       = "GitHub Actions Provider"
+  description                        = "OIDC provider for GitHub Actions"
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.repository" = "assertion.repository"
+    "attribute.owner"      = "assertion.repository_owner"
+  }
+
+  attribute_condition = "assertion.repository_owner == '${var.github_owner}'"
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+# =============================================================================
+# Service Account ↔ Workload Identity Pool Binding
+# =============================================================================
+
+resource "google_service_account_iam_member" "github_actions_wif" {
+  service_account_id = google_service_account.github_actions.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_pool.name}/attribute.repository/${var.github_owner}/${var.github_repo}"
+}

--- a/infrastructure/terraform/modules/github_wif/outputs.tf
+++ b/infrastructure/terraform/modules/github_wif/outputs.tf
@@ -1,0 +1,11 @@
+# GitHub WIF Module Outputs
+
+output "workload_identity_provider" {
+  description = "The Workload Identity Provider resource name (for GitHub Secret GCP_WORKLOAD_IDENTITY_PROVIDER)"
+  value       = google_iam_workload_identity_pool_provider.github_provider.name
+}
+
+output "service_account_email" {
+  description = "The GitHub Actions service account email (for GitHub Secret GCP_SERVICE_ACCOUNT)"
+  value       = google_service_account.github_actions.email
+}

--- a/infrastructure/terraform/modules/github_wif/variables.tf
+++ b/infrastructure/terraform/modules/github_wif/variables.tf
@@ -1,0 +1,16 @@
+# GitHub WIF Module Variables
+
+variable "project_id" {
+  description = "The GCP project ID"
+  type        = string
+}
+
+variable "github_owner" {
+  description = "GitHub repository owner (e.g. 'arakitakashi')"
+  type        = string
+}
+
+variable "github_repo" {
+  description = "GitHub repository name (e.g. 'homework-coach-robo')"
+  type        = string
+}


### PR DESCRIPTION
## Summary

GitHub Actions の CI/CD で使用する Workload Identity Federation (WIF) リソースを Terraform モジュールとして IaC 管理します。

### 変更内容

- **新規モジュール `modules/github_wif/`**: Service Account、WIF Pool、OIDC Provider、IAM bindings を作成
- **`bootstrap/main.tf`**: `iamcredentials.googleapis.com` API を追加
- **`environments/dev/`**: モジュール呼び出し、変数、出力を追加

### 設計判断

既存の `modules/iam/` には追加せず、新規モジュールとして分離:
- IAM モジュールは Cloud Run サービスアカウント専用で責務が異なる
- WIF はライフサイクルが独立（GitHub 連携の有無で変わる）

### 適用手順

```bash
# 1. Bootstrap（API有効化）
cd infrastructure/terraform/bootstrap
terraform init && terraform apply

# 2. Dev環境に適用
cd ../environments/dev
terraform init && terraform plan && terraform apply

# 3. 出力値を確認し、GitHub Secrets を更新
terraform output github_wif_provider
terraform output github_wif_service_account
```

## Test plan

- [x] `terraform fmt -check -recursive` でフォーマット確認済み
- [x] `terraform validate` でモジュール構文確認済み
- [x] `terraform plan` で WIF リソース作成のみの差分であることを確認（9 to add, 0 change, 0 destroy）
- [x] `terraform apply` 完了、GitHub Actions ワークフロー再実行で認証成功を確認（[Run #21786541485](https://github.com/arakitakashi/homework-coach-robo/actions/runs/21786541485)）

🤖 Generated with [Claude Code](https://claude.com/claude-code)