### PR TITLE
feat(infra): Add Phase 2 infrastructure with feature flags

### DIFF
--- a/.steering/20260208-infra-phase2/design.md
+++ b/.steering/20260208-infra-phase2/design.md
@@ -1,0 +1,39 @@
+# Design - Infrastructure Phase 2 Update
+
+## アーキテクチャ概要
+
+既存のTerraformモジュール構造を維持しつつ、Feature flagパターンで Phase 2 リソースを条件付き作成する。
+
+## 技術選定
+
+- **Feature Flag パターン**: `count = var.enable_xxx ? 1 : 0` で条件付きリソース作成
+- **動的ブロック**: Cloud Run環境変数に `dynamic "env"` ブロック使用
+- **既存モジュール拡張**: 新モジュール作成せず、variables.tf/main.tf への追加で対応
+
+## ファイル構成
+
+変更対象: 16ファイル（既存ファイルのみ）
+
+| Module | Files | Changes |
+|--------|-------|---------|
+| bootstrap | main.tf | API追加 |
+| environments/dev | main.tf, variables.tf, outputs.tf | 配線・flag・output |
+| iam | main.tf, variables.tf | 条件付きIAMロール |
+| secret_manager | main.tf, variables.tf, outputs.tf | Gemini APIキー |
+| firestore | indexes.tf, variables.tf | 5インデックス |
+| bigquery | tables.tf, variables.tf, outputs.tf | 3テーブル |
+| cloud_run | main.tf, variables.tf | 動的env |
+
+## セキュリティ考慮事項
+
+- IAMロールは最小権限原則に従い、条件付きで追加
+- Gemini APIキーはSecret Managerで管理
+- Feature flagで不要なリソースは作成しない
+
+## 代替案と採用理由
+
+| 案 | 採否 | 理由 |
+|----|------|------|
+| 新モジュール作成 | ❌ | 既存モジュール拡張で十分 |
+| 全リソース常時作成 | ❌ | 不要なコスト・権限が発生 |
+| Feature flag + count | ✅ | 段階的有効化、後方互換性 |

--- a/.steering/20260208-infra-phase2/requirements.md
+++ b/.steering/20260208-infra-phase2/requirements.md
@@ -1,0 +1,55 @@
+# Requirements - Infrastructure Phase 2 Update
+
+## 背景・目的
+
+Phase 2開発開始に伴い、既存のTerraformインフラをPhase 2（ツール導入、マルチエージェント、RAG、感情適応）に対応させる。現在のインフラはPhase 1/MVPの構成。Phase 2では新しいGCPサービス、IAMロール、BigQueryテーブル、Firestoreインデックス、環境変数が必要。
+
+## 要求事項
+
+### 機能要件
+
+1. **Discovery Engine API有効化** - RAG用のVertex AI Discovery Engine
+2. **IAMロール追加** - discoveryengine.editor, storage.objectAdmin（条件付き）
+3. **Secret Manager拡張** - Gemini APIキーシークレット（条件付き）
+4. **Firestoreインデックス追加** - Phase 2a/2b/2d用の5インデックス
+5. **BigQueryテーブル追加** - agent_metrics, emotion_analysis, rag_metrics
+6. **Cloud Run環境変数** - バックエンドへの動的環境変数注入
+7. **環境レベル配線** - Feature flagで段階的有効化
+
+### 非機能要件
+
+- 後方互換性の維持（既存リソースに影響なし）
+- Feature flagがfalseの場合、差分なし
+- 既存モジュール拡張（新モジュール作成不要）
+
+### 制約条件
+
+- Terraform >= 1.5.0
+- Google Provider ~> 5.0
+- 既存のリソース名・構造を変更しない
+
+## 対象範囲
+
+### In Scope
+
+- bootstrap API追加
+- 環境レベルAPI追加
+- IAMモジュール更新
+- Secret Managerモジュール更新
+- Firestoreインデックス追加
+- BigQueryテーブル追加
+- Cloud Runモジュール更新
+- 環境レベル配線
+
+### Out of Scope
+
+- 実際のアプリケーションコード変更
+- Vertex AI Discovery Engine corpusの作成（アプリ層で実施）
+- 新モジュールの作成
+- staging/production環境の設定
+
+## 成功基準
+
+- `terraform validate` が成功する
+- Feature flags全てfalseで `terraform plan` に差分なし
+- 各Feature flagをtrueにした際、適切なリソースのみ追加される

--- a/.steering/20260208-infra-phase2/tasklist.md
+++ b/.steering/20260208-infra-phase2/tasklist.md
@@ -1,0 +1,32 @@
+# Task List - Infrastructure Phase 2 Update
+
+## Phase 1: API有効化
+
+- [x] bootstrap/main.tf に discoveryengine.googleapis.com 追加
+- [x] environments/dev/main.tf に discoveryengine.googleapis.com 追加
+
+## Phase 2: モジュール更新
+
+- [x] IAM: variables.tf に feature flag 追加
+- [x] IAM: main.tf に条件付きIAMロール追加
+- [x] Secret Manager: variables.tf に feature flag 追加
+- [x] Secret Manager: main.tf に gemini-api-key シークレット追加
+- [x] Secret Manager: outputs.tf に output 追加
+- [x] Firestore: variables.tf に feature flag 追加
+- [x] Firestore: indexes.tf に5インデックス追加
+- [x] BigQuery: variables.tf に feature flag 追加
+- [x] BigQuery: tables.tf に3テーブル追加
+- [x] BigQuery: outputs.tf に output 追加
+- [x] Cloud Run: variables.tf に env_vars 変数追加
+- [x] Cloud Run: main.tf に dynamic env ブロック追加
+
+## Phase 3: 環境レベル配線
+
+- [x] environments/dev/variables.tf に feature flag 変数追加
+- [x] environments/dev/main.tf にモジュール配線追加
+- [x] environments/dev/outputs.tf に Phase 2 output 追加
+
+## Phase 4: 検証
+
+- [x] terraform validate 成功確認
+- [ ] コミット

--- a/infrastructure/terraform/bootstrap/main.tf
+++ b/infrastructure/terraform/bootstrap/main.tf
@@ -88,6 +88,7 @@ locals {
     "iam.googleapis.com",                  # IAM
     "iamcredentials.googleapis.com",       # IAM Credentials (for WIF)
     "cloudresourcemanager.googleapis.com", # Resource Manager
+    "discoveryengine.googleapis.com",      # Discovery Engine (RAG - Phase 2c)
   ]
 }
 

--- a/infrastructure/terraform/environments/dev/outputs.tf
+++ b/infrastructure/terraform/environments/dev/outputs.tf
@@ -79,6 +79,27 @@ output "github_wif_service_account" {
   value       = module.github_wif.service_account_email
 }
 
+# Phase 2 outputs
+output "phase2_gemini_api_key_secret_id" {
+  description = "The Gemini API key secret ID (if created)"
+  value       = module.secret_manager.gemini_api_key_secret_id
+}
+
+output "phase2_bigquery_agent_metrics_table" {
+  description = "The agent_metrics BigQuery table ID (if created)"
+  value       = module.bigquery.agent_metrics_table_id
+}
+
+output "phase2_bigquery_emotion_analysis_table" {
+  description = "The emotion_analysis BigQuery table ID (if created)"
+  value       = module.bigquery.emotion_analysis_table_id
+}
+
+output "phase2_bigquery_rag_metrics_table" {
+  description = "The rag_metrics BigQuery table ID (if created)"
+  value       = module.bigquery.rag_metrics_table_id
+}
+
 # Summary for easy reference
 output "summary" {
   description = "Summary of important resources"
@@ -92,5 +113,10 @@ output "summary" {
     assets_bucket      = module.cloud_storage.bucket_name
     firestore_database = module.firestore.database_name
     bigquery_dataset   = module.bigquery.dataset_id
+    # Phase 2 flags
+    phase2_tools       = var.enable_phase2_tools
+    phase2_multi_agent = var.enable_phase2_multi_agent
+    phase2_rag         = var.enable_phase2_rag
+    phase2_emotion     = var.enable_phase2_emotion
   }
 }

--- a/infrastructure/terraform/environments/dev/variables.tf
+++ b/infrastructure/terraform/environments/dev/variables.tf
@@ -55,3 +55,37 @@ variable "enable_cdn" {
   type        = bool
   default     = false
 }
+
+# =============================================================================
+# Phase 2 Feature Flags
+# =============================================================================
+
+variable "enable_phase2_tools" {
+  description = "Enable Phase 2a: ADK tools infrastructure"
+  type        = bool
+  default     = false
+}
+
+variable "enable_phase2_multi_agent" {
+  description = "Enable Phase 2b: Multi-agent infrastructure"
+  type        = bool
+  default     = false
+}
+
+variable "enable_phase2_rag" {
+  description = "Enable Phase 2c: RAG infrastructure (Discovery Engine, indexes, tables)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_phase2_emotion" {
+  description = "Enable Phase 2d: Emotion analysis infrastructure"
+  type        = bool
+  default     = false
+}
+
+variable "backend_memory" {
+  description = "Memory limit for backend (Phase 2 may need more)"
+  type        = string
+  default     = "1Gi"
+}

--- a/infrastructure/terraform/modules/bigquery/outputs.tf
+++ b/infrastructure/terraform/modules/bigquery/outputs.tf
@@ -24,3 +24,19 @@ output "learning_profile_snapshots_table_id" {
   description = "The fully qualified table ID for learning_profile_snapshots"
   value       = "${var.project_id}.${google_bigquery_dataset.main.dataset_id}.${google_bigquery_table.learning_profile_snapshots.table_id}"
 }
+
+# Phase 2 outputs
+output "agent_metrics_table_id" {
+  description = "The fully qualified table ID for agent_metrics (if created)"
+  value       = var.enable_phase2_tables ? "${var.project_id}.${google_bigquery_dataset.main.dataset_id}.${google_bigquery_table.agent_metrics[0].table_id}" : null
+}
+
+output "emotion_analysis_table_id" {
+  description = "The fully qualified table ID for emotion_analysis (if created)"
+  value       = var.enable_phase2_tables ? "${var.project_id}.${google_bigquery_dataset.main.dataset_id}.${google_bigquery_table.emotion_analysis[0].table_id}" : null
+}
+
+output "rag_metrics_table_id" {
+  description = "The fully qualified table ID for rag_metrics (if created)"
+  value       = var.enable_phase2_tables ? "${var.project_id}.${google_bigquery_dataset.main.dataset_id}.${google_bigquery_table.rag_metrics[0].table_id}" : null
+}

--- a/infrastructure/terraform/modules/bigquery/variables.tf
+++ b/infrastructure/terraform/modules/bigquery/variables.tf
@@ -27,3 +27,10 @@ variable "backend_service_account_email" {
   description = "Email of the backend service account for dataset access"
   type        = string
 }
+
+# Phase 2 Feature Flags
+variable "enable_phase2_tables" {
+  description = "Enable Phase 2 BigQuery tables (agent_metrics, emotion_analysis, rag_metrics)"
+  type        = bool
+  default     = false
+}

--- a/infrastructure/terraform/modules/cloud_run/main.tf
+++ b/infrastructure/terraform/modules/cloud_run/main.tf
@@ -63,6 +63,15 @@ resource "google_cloud_run_v2_service" "backend" {
       }
       # NOTE: PORT is automatically set by Cloud Run (8080)
 
+      # Additional environment variables (Phase 2)
+      dynamic "env" {
+        for_each = var.backend_env_vars
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
       # Secret environment variables
       dynamic "env" {
         for_each = var.backend_secrets

--- a/infrastructure/terraform/modules/cloud_run/variables.tf
+++ b/infrastructure/terraform/modules/cloud_run/variables.tf
@@ -146,6 +146,13 @@ variable "frontend_concurrency" {
   default     = 80
 }
 
+# Backend additional environment variables (Phase 2)
+variable "backend_env_vars" {
+  description = "Additional environment variables for backend service"
+  type        = map(string)
+  default     = {}
+}
+
 # IAM Configuration
 variable "allow_unauthenticated_backend" {
   description = "Allow unauthenticated access to backend (for development)"

--- a/infrastructure/terraform/modules/firestore/indexes.tf
+++ b/infrastructure/terraform/modules/firestore/indexes.tf
@@ -129,3 +129,112 @@ resource "google_firestore_index" "users_by_parent" {
 
   depends_on = [google_firestore_database.main]
 }
+
+# =============================================================================
+# Phase 2 Indexes (conditional)
+# =============================================================================
+
+# Phase 2a: Curriculum items by subject and grade level
+resource "google_firestore_index" "curriculum_by_subject_grade" {
+  count      = var.enable_phase2_indexes ? 1 : 0
+  project    = var.project_id
+  database   = google_firestore_database.main.name
+  collection = "curriculum"
+
+  fields {
+    field_path = "subject"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "gradeLevel"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "unit"
+    order      = "ASCENDING"
+  }
+
+  depends_on = [google_firestore_database.main]
+}
+
+# Phase 2b: Agent configs by name
+resource "google_firestore_index" "agent_configs_by_name" {
+  count      = var.enable_phase2_indexes ? 1 : 0
+  project    = var.project_id
+  database   = google_firestore_database.main.name
+  collection = "agent_configs"
+
+  fields {
+    field_path = "agentName"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "version"
+    order      = "DESCENDING"
+  }
+
+  depends_on = [google_firestore_database.main]
+}
+
+# Phase 2b: Active agent configs
+resource "google_firestore_index" "agent_configs_active" {
+  count      = var.enable_phase2_indexes ? 1 : 0
+  project    = var.project_id
+  database   = google_firestore_database.main.name
+  collection = "agent_configs"
+
+  fields {
+    field_path = "isActive"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "agentName"
+    order      = "ASCENDING"
+  }
+
+  depends_on = [google_firestore_database.main]
+}
+
+# Phase 2d: Emotion analysis by session
+resource "google_firestore_index" "emotion_analysis_by_session" {
+  count      = var.enable_phase2_indexes ? 1 : 0
+  project    = var.project_id
+  database   = google_firestore_database.main.name
+  collection = "emotion_analysis"
+
+  fields {
+    field_path = "sessionId"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "analyzedAt"
+    order      = "DESCENDING"
+  }
+
+  depends_on = [google_firestore_database.main]
+}
+
+# Phase 2d: Emotion analysis by user
+resource "google_firestore_index" "emotion_analysis_by_user" {
+  count      = var.enable_phase2_indexes ? 1 : 0
+  project    = var.project_id
+  database   = google_firestore_database.main.name
+  collection = "emotion_analysis"
+
+  fields {
+    field_path = "userId"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "analyzedAt"
+    order      = "DESCENDING"
+  }
+
+  depends_on = [google_firestore_database.main]
+}

--- a/infrastructure/terraform/modules/firestore/variables.tf
+++ b/infrastructure/terraform/modules/firestore/variables.tf
@@ -16,3 +16,10 @@ variable "environment" {
   type        = string
   default     = "dev"
 }
+
+# Phase 2 Feature Flags
+variable "enable_phase2_indexes" {
+  description = "Enable Phase 2 Firestore composite indexes"
+  type        = bool
+  default     = false
+}

--- a/infrastructure/terraform/modules/iam/main.tf
+++ b/infrastructure/terraform/modules/iam/main.tf
@@ -96,6 +96,22 @@ resource "google_project_iam_member" "backend_redis" {
   member  = "serviceAccount:${google_service_account.backend.email}"
 }
 
+# Phase 2c: Discovery Engine (RAG) access
+resource "google_project_iam_member" "backend_discovery_engine" {
+  count   = var.enable_phase2_rag ? 1 : 0
+  project = var.project_id
+  role    = "roles/discoveryengine.editor"
+  member  = "serviceAccount:${google_service_account.backend.email}"
+}
+
+# Phase 2c: Cloud Storage admin for RAG data upload
+resource "google_project_iam_member" "backend_storage_admin" {
+  count   = var.enable_phase2_storage_admin ? 1 : 0
+  project = var.project_id
+  role    = "roles/storage.objectAdmin"
+  member  = "serviceAccount:${google_service_account.backend.email}"
+}
+
 # Frontend Service Account Roles
 # Secret Manager access (for API keys, etc.)
 resource "google_project_iam_member" "frontend_secret_accessor" {

--- a/infrastructure/terraform/modules/iam/variables.tf
+++ b/infrastructure/terraform/modules/iam/variables.tf
@@ -10,3 +10,16 @@ variable "name_prefix" {
   type        = string
   default     = "homework-coach"
 }
+
+# Phase 2 Feature Flags
+variable "enable_phase2_rag" {
+  description = "Enable IAM roles for Phase 2c RAG (Discovery Engine)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_phase2_storage_admin" {
+  description = "Enable storage.objectAdmin role for RAG data upload"
+  type        = bool
+  default     = false
+}

--- a/infrastructure/terraform/modules/secret_manager/outputs.tf
+++ b/infrastructure/terraform/modules/secret_manager/outputs.tf
@@ -31,3 +31,14 @@ output "api_key_secret_name" {
   description = "The resource name of the API key secret (if created)"
   value       = var.create_api_key_secret ? google_secret_manager_secret.api_key[0].name : null
 }
+
+# Phase 2 outputs
+output "gemini_api_key_secret_id" {
+  description = "The ID of the Gemini API key secret (if created)"
+  value       = var.create_gemini_api_key_secret ? google_secret_manager_secret.gemini_api_key[0].secret_id : null
+}
+
+output "gemini_api_key_secret_name" {
+  description = "The resource name of the Gemini API key secret (if created)"
+  value       = var.create_gemini_api_key_secret ? google_secret_manager_secret.gemini_api_key[0].name : null
+}

--- a/infrastructure/terraform/modules/secret_manager/variables.tf
+++ b/infrastructure/terraform/modules/secret_manager/variables.tf
@@ -32,3 +32,10 @@ variable "create_api_key_secret" {
   type        = bool
   default     = false
 }
+
+# Phase 2 Feature Flags
+variable "create_gemini_api_key_secret" {
+  description = "Whether to create the Gemini API key secret (Phase 2)"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary

- Extend existing Terraform modules to support Phase 2 development (ADK tools, multi-agent, RAG, emotion analysis)
- All resources are controlled by feature flags (default: `false`), ensuring zero impact on existing infrastructure
- 16 files modified across 7 modules: bootstrap, iam, secret_manager, firestore, bigquery, cloud_run, environments/dev

### Feature Flags

| Flag | Resources Created |
|------|-------------------|
| `enable_phase2_tools` | Gemini API key secret, Firestore indexes, `ENABLE_ADK_TOOLS` env var |
| `enable_phase2_multi_agent` | Gemini API key secret, Firestore indexes, BigQuery tables, `ENABLE_MULTI_AGENT` env var |
| `enable_phase2_rag` | Discovery Engine IAM roles, BigQuery tables, `ENABLE_RAG` env var |
| `enable_phase2_emotion` | Firestore indexes, BigQuery tables, `ENABLE_EMOTION_ANALYSIS` env var |

### New Resources (conditional)

- **IAM**: `discoveryengine.editor`, `storage.objectAdmin` roles
- **Secret Manager**: `gemini-api-key` secret
- **Firestore**: 5 composite indexes (curriculum, agent_configs x2, emotion_analysis x2)
- **BigQuery**: 3 analytics tables (agent_metrics, emotion_analysis, rag_metrics)
- **Cloud Run**: Dynamic env block for Phase 2 configuration
- **APIs**: `discoveryengine.googleapis.com`

### Validation

- `terraform init -backend=false` + `terraform validate` passed for both bootstrap and environments/dev

## Test plan

- [x] `terraform validate` passes for bootstrap configuration
- [x] `terraform validate` passes for environments/dev configuration
- [ ] `terraform plan` with all flags `false` shows no changes (requires GCP credentials)
- [ ] `terraform plan` with flags `true` shows expected resources only

🤖 Generated with [Claude Code](https://claude.com/claude-code)