### PR TITLE
chore: Add Claude Code sandbox settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,7 @@
 	"sandbox": {
 		"enabled": true,
 		"autoAllowBashIfSandboxed": true,
-		"excludedCommands": ["docker"],
+		"excludedCommands": ["docker", "gh"],
 		"allowUnsandboxedCommands": true,
 		"network": {
 			"allowedDomains": [


### PR DESCRIPTION
## Summary
- Claude Code CLI のサンドボックス機能を有効化
- OS レベルのサンドボックス（macOS Seatbelt）で Bash ツール実行を保護
- サンドボックス内コマンドの自動承認を有効化（`autoAllowBashIfSandboxed: true`）
- プロジェクト依存のネットワークドメインをホワイトリスト設定:
  - GitHub (`github.com`, `*.github.com`)
  - npm (`registry.npmjs.org`, `*.npmjs.org`)
  - Terraform (`registry.terraform.io`)
  - GCP (`*.googleapis.com`)
  - Python (`pypi.org`, `files.pythonhosted.org`)
  - Claude API (`api.anthropic.com`)
- Docker コマンドはサンドボックス除外（`excludedCommands`）

## Test plan
- [ ] Claude Code CLI を再起動し、サンドボックスが有効であることを確認
- [ ] `git status` 等の基本コマンドがサンドボックス内で自動実行されることを確認
- [ ] `terraform init` 等のネットワークアクセスが必要なコマンドが正常動作することを確認
- [ ] 許可外ドメインへのアクセスがブロックされることを確認

:robot: Generated with [Claude Code](https://claude.com/claude-code)