### PR TITLE
fix(ci): Claude Code Review をオンデマンド実行に変更

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,22 +2,11 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    types: [labeled]
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    if: github.event.label.name == 'claude-review'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -39,6 +28,3 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.steering/20260210-claude-review-on-demand/design.md
+++ b/.steering/20260210-claude-review-on-demand/design.md
@@ -1,0 +1,24 @@
+# Design - Claude Code Review オンデマンド化
+
+## 変更対象
+
+`.github/workflows/claude-code-review.yml` のみ
+
+## 変更内容
+
+### Before
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+```
+
+### After
+```yaml
+on:
+  pull_request:
+    types: [labeled]
+```
+
+- `labeled` イベントで `claude-review` ラベルが付与された時のみ実行
+- job レベルで `if: github.event.label.name == 'claude-review'` 条件を追加

--- a/.steering/20260210-claude-review-on-demand/requirements.md
+++ b/.steering/20260210-claude-review-on-demand/requirements.md
@@ -1,0 +1,21 @@
+# Requirements - Claude Code Review オンデマンド化
+
+## 背景・目的
+
+GitHub Actions での Claude 使用量が多い。原因は `claude-code-review.yml` が全PRで自動実行されていること。レビューは明示的に求められた時のみ実行するように変更する。
+
+## 要求事項
+
+### 機能要件
+
+- Claude Code Review は PR にラベル `claude-review` が付与された時のみ実行される
+- `claude.yml`（@claude メンション対応）は現状維持
+
+### 非機能要件
+
+- 既存の CI ワークフロー（ci-backend, ci-frontend, ci-e2e, cd, deploy）に影響を与えない
+
+## 成功基準
+
+- PR 作成時に自動で Claude Code Review が実行されない
+- `claude-review` ラベル付与時のみ実行される

--- a/.steering/20260210-claude-review-on-demand/tasklist.md
+++ b/.steering/20260210-claude-review-on-demand/tasklist.md
@@ -1,0 +1,7 @@
+# Task List - Claude Code Review オンデマンド化
+
+## Phase 1: 実装
+
+- [x] `claude-code-review.yml` のトリガーをラベルベースに変更
+- [ ] コミット・プッシュ
+- [ ] PR 作成


### PR DESCRIPTION
## Summary
- `claude-code-review.yml` のトリガーを全PR自動実行からラベルベースのオンデマンド実行に変更
- PRに `claude-review` ラベルを付与した時のみ Claude Code Review が実行される

## 変更内容

| 項目 | Before | After |
|------|--------|-------|
| トリガー | `opened, synchronize, ready_for_review, reopened` | `labeled` |
| 実行条件 | 全PR自動 | `claude-review` ラベル付与時のみ |

### 影響のないワークフロー
- `claude.yml`（`@claude` メンション対応）: 変更なし
- `ci-backend.yml`, `ci-frontend.yml`, `ci-e2e.yml`: 変更なし
- `cd.yml`, `deploy.yml`: 変更なし

## 使い方
1. PRで Claude レビューが必要な場合、`claude-review` ラベルを付与
2. ワークフローが実行され、レビューコメントが投稿される

## Test plan
- [ ] `claude-review` ラベルなしでPR作成時にワークフローが実行されないことを確認
- [ ] `claude-review` ラベル付与時にワークフローが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)