### PR TITLE
fix(infra): update Agent Engine dependencies to enable dashboard and tracing

### DIFF
--- a/.steering/20260212-fix-agent-engine-dependencies/design.md
+++ b/.steering/20260212-fix-agent-engine-dependencies/design.md
@@ -1,0 +1,83 @@
+# Design - Fix Agent Engine Dependencies and Enable Dashboard/Tracing
+
+## アーキテクチャ概要
+
+Agent Engine のダッシュボードとトレースを有効化するため、以下の2つのファイルを更新する：
+
+1. **backend/agent_engine_requirements.txt**: ランタイム依存関係
+2. **backend/scripts/deploy_agent_engine.py**: デプロイスクリプトの requirements
+
+Terraform での環境変数設定については、調査の結果、明確なドキュメントが見つからなかったため、依存関係のバージョン更新のみで対応する。
+
+## 技術選定
+
+### 依存関係のバージョン
+
+Google の要求に基づき、以下のバージョンを使用：
+
+- `google-cloud-aiplatform[agent_engines,adk]>=1.126.1`
+- `google-adk>=1.18.0`
+
+### Terraform での環境変数設定
+
+調査の結果、Terraform の `google_vertex_ai_reasoning_engine` リソースでは、環境変数を設定するフィールドが明示的にドキュメント化されていない。Google の警告メッセージは Python SDK で直接デプロイする場合を指している可能性が高く、Terraform の場合は依存関係のバージョンが正しければ自動的にダッシュボードとトレースが有効になると考えられる。
+
+## データ設計
+
+変更なし（依存関係のバージョン更新のみ）。
+
+## API設計
+
+変更なし（依存関係のバージョン更新のみ）。
+
+## ファイル構成
+
+### 変更対象ファイル
+
+1. **backend/agent_engine_requirements.txt**
+   ```
+   google-cloud-aiplatform[agent_engines,adk]>=1.126.1
+   google-adk>=1.18.0
+   cloudpickle==3.0.0
+   google-cloud-firestore>=2.19.0
+   pydantic>=2.12.0
+   ```
+
+2. **backend/scripts/deploy_agent_engine.py**
+   - L80-82: `requirements` を更新
+   - L121-124: `requirements` を更新
+   ```python
+   "requirements": [
+       "google-cloud-aiplatform[adk,agent_engines]>=1.126.1",
+       "google-adk>=1.18.0",
+       "google-cloud-firestore>=2.19.0",
+   ]
+   ```
+
+## 依存関係
+
+- Google Cloud Vertex AI SDK: v1.126.1+
+- Google ADK: v1.18.0+
+
+## エラーハンドリング
+
+- 依存関係のバージョン互換性エラー: CI/CD パイプラインで検出
+- Terraform apply エラー: 手動介入が必要
+
+## セキュリティ考慮事項
+
+- 依存関係のバージョン更新による脆弱性修正の恩恵を受ける
+
+## パフォーマンス考慮事項
+
+- ダッシュボードとトレースの有効化により、モニタリングとデバッグが改善される
+
+## 代替案と採用理由
+
+### 代替案1: Terraform での環境変数設定を実装
+
+調査したが、明確なドキュメントが見つからなかったため、実装を見送る。
+
+### 採用案: 依存関係のバージョン更新のみ
+
+まず依存関係のバージョンを更新し、実際にデプロイしてダッシュボードとトレースが有効になるかを確認する。必要に応じて追加対応を行う。

--- a/.steering/20260212-fix-agent-engine-dependencies/requirements.md
+++ b/.steering/20260212-fix-agent-engine-dependencies/requirements.md
@@ -1,0 +1,64 @@
+# Requirements - Fix Agent Engine Dependencies and Enable Dashboard/Tracing
+
+## 背景・目的
+
+Agent Engine のダッシュボードとトレースが使用不可の状態になっている。GCP コンソールで以下の警告が表示される：
+
+> このエージェントではダッシュボードとトレースを使用できません。考えられる理由は次のいずれかです。
+>
+> - 古い依存関係: エージェントが v1.126.1 以上の google-cloud-aiplatform と v1.18.0 以上の google-adk を使用していることを確認してください
+> - 手動 API デプロイ: エージェントが新しいバージョンを使用している場合でも、API を介してデプロイするときは、環境変数を明示的に設定する必要があります
+
+本作業では、依存関係のバージョンを更新し、必要に応じて環境変数を設定して、ダッシュボードとトレースを有効化する。
+
+## 要求事項
+
+### 機能要件
+
+1. **依存関係のバージョン更新**
+   - `google-cloud-aiplatform[agent_engines,adk]>=1.126.1`
+   - `google-adk>=1.18.0`
+   - 以下のファイルを更新：
+     - `backend/agent_engine_requirements.txt`
+     - `backend/scripts/deploy_agent_engine.py`
+
+2. **Terraform での環境変数設定（必要に応じて）**
+   - `google_vertex_ai_reasoning_engine` リソースに環境変数を追加する方法を調査
+   - 必要に応じて `spec.environment_variables` などを追加
+
+3. **Agent Engine 再デプロイ**
+   - CI/CD パイプラインで自動デプロイ（`.github/workflows/cd.yml`）
+   - Terraform apply で Agent Engine 更新
+
+### 非機能要件
+
+1. **後方互換性**: 既存の機能に影響を与えない
+2. **検証可能性**: GCP コンソールでダッシュボードとトレースが表示されることを確認
+
+### 制約条件
+
+1. Terraform google-beta provider の機能に依存
+2. GCP のドキュメントに従った環境変数設定が必要な場合がある
+
+## 対象範囲
+
+### In Scope
+
+- `backend/agent_engine_requirements.txt` のバージョン更新
+- `backend/scripts/deploy_agent_engine.py` の requirements 更新
+- Terraform での環境変数設定の調査と実装（必要に応じて）
+- CI/CD パイプラインでの自動デプロイ
+
+### Out of Scope
+
+- Agent Engine の機能追加・変更
+- バックエンドコードの変更
+
+## 成功基準
+
+- [ ] `agent_engine_requirements.txt` のバージョンが最新（`>=1.126.1`, `>=1.18.0`）
+- [ ] `deploy_agent_engine.py` の requirements が最新
+- [ ] Terraform で環境変数が設定されている（必要に応じて）
+- [ ] CI/CD パイプラインで新しいアーティファクトがデプロイされる
+- [ ] `terraform apply` で Agent Engine が更新される
+- [ ] GCP コンソールでダッシュボードとトレースが使用可能になる

--- a/.steering/20260212-fix-agent-engine-dependencies/tasklist.md
+++ b/.steering/20260212-fix-agent-engine-dependencies/tasklist.md
@@ -1,0 +1,34 @@
+# Task List - Fix Agent Engine Dependencies and Enable Dashboard/Tracing
+
+## Phase 1: 環境セットアップ
+
+- [x] ステアリングディレクトリの作成
+- [x] requirements.md の作成
+- [x] design.md の作成
+- [x] tasklist.md の作成
+
+## Phase 2: 依存関係のバージョン更新
+
+- [ ] `backend/agent_engine_requirements.txt` を更新
+  - `google-cloud-aiplatform[agent_engines,adk]>=1.126.1`
+  - `google-adk>=1.18.0`
+- [ ] `backend/scripts/deploy_agent_engine.py` を更新
+  - L80-82: requirements を更新
+  - L121-124: requirements を更新
+
+## Phase 3: 動作確認
+
+- [ ] 変更内容の確認（git diff）
+- [ ] コミット・プッシュ
+
+## Phase 4: 品質チェック
+
+- [ ] コードレビュー（セルフレビュー）
+- [ ] ドキュメント更新
+  - [ ] `CLAUDE.md` の Development Context 更新
+  - [ ] `docs/implementation-status.md` の更新
+
+## Phase 5: PR作成
+
+- [ ] PR作成
+- [ ] Issue #108 にリンク

--- a/backend/agent_engine_requirements.txt
+++ b/backend/agent_engine_requirements.txt
@@ -4,7 +4,7 @@
 # Google ADK & GenAI
 google-adk>=1.23.0
 google-genai>=1.0.0
-google-cloud-aiplatform[adk,agent_engines]>=1.88.0
+google-cloud-aiplatform[adk,agent_engines]>=1.126.1
 
 # Serialization
 cloudpickle>=3.0.0

--- a/backend/scripts/deploy_agent_engine.py
+++ b/backend/scripts/deploy_agent_engine.py
@@ -77,7 +77,8 @@ def deploy_agent(
                 "description": "宿題コーチロボット - Router Agent (Phase 3)",
                 "staging_bucket": f"gs://{staging_bucket}",
                 "requirements": [
-                    "google-cloud-aiplatform[adk,agent_engines]>=1.88.0",
+                    "google-cloud-aiplatform[adk,agent_engines]>=1.126.1",
+                    "google-adk>=1.23.0",
                     "google-cloud-firestore>=2.19.0",
                 ],
             },
@@ -119,7 +120,8 @@ def agent_engines_update(
         config={
             "staging_bucket": f"gs://{staging_bucket}",
             "requirements": [
-                "google-cloud-aiplatform[adk,agent_engines]>=1.88.0",
+                "google-cloud-aiplatform[adk,agent_engines]>=1.126.1",
+                "google-adk>=1.23.0",
                 "google-cloud-firestore>=2.19.0",
             ],
         },


### PR DESCRIPTION
## Summary

- Update `google-cloud-aiplatform` to `>=1.126.1` to enable Agent Engine dashboard and tracing
- Update `google-adk` to `>=1.23.0` (already satisfied, added explicit version in deploy script)
- Updated `agent_engine_requirements.txt` and `deploy_agent_engine.py` to use new versions
- Addresses GCP console warning about unavailable dashboard and tracing features

## Changes

- `backend/agent_engine_requirements.txt`: Updated `google-cloud-aiplatform` from `>=1.88.0` to `>=1.126.1`
- `backend/scripts/deploy_agent_engine.py`: 
  - Updated requirements in `deploy_agent()` function (L80-82)
  - Updated requirements in `agent_engines_update()` function (L121-124)
  - Added explicit `google-adk>=1.23.0` dependency

## Test plan

- [ ] Verify CI/CD pipeline passes (cd.yml → deploy-agent-engine job)
- [ ] Confirm Agent Engine artifact is uploaded to GCS staging bucket
- [ ] Run `terraform apply` to update Agent Engine with new dependencies
- [ ] Verify dashboard and tracing are enabled in GCP Console:
  - Navigate to Vertex AI → Agent Builder → Agents
  - Select the deployed agent
  - Confirm dashboard and tracing tabs are available
- [ ] Test existing Agent Engine functionality (session creation, dialogue flow)

## Related

Fixes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)