### PR TITLE
fix(backend): AgentEngine ラッパーに create_session / stream_query メソッドを追加

### DIFF
--- a/.steering/20260213-fix-agent-engine-missing-methods/design.md
+++ b/.steering/20260213-fix-agent-engine-missing-methods/design.md
@@ -1,0 +1,51 @@
+# Design - AgentEngine ラッパーメソッド追加
+
+## アーキテクチャ概要
+
+Agent Engine デプロイフロー:
+1. `serialize_agent.py` で `HomeworkCoachAgent` を cloudpickle シリアライズ
+2. GCS にアップロード → Agent Engine にデプロイ
+3. クライアントが `agent_engines.get()` でプロキシ取得
+4. プロキシが sync メソッドから `async_*` を自動生成
+
+## 実装詳細
+
+### `create_session(self, *, user_id: str) -> dict`
+
+```python
+def create_session(self, *, user_id: str) -> dict:
+    runner = self._get_runner()
+    session = asyncio.run(
+        runner.session_service.create_session(
+            app_name="homework-coach-agent-engine",
+            user_id=user_id,
+        )
+    )
+    return {"id": session.id}
+```
+
+### `stream_query(self, *, user_id: str, session_id: str, message: str) -> Generator`
+
+```python
+def stream_query(self, *, user_id: str, session_id: str, message: str):
+    content = types.Content(role="user", parts=[types.Part(text=message)])
+
+    async def collect_events():
+        events = []
+        async for event in runner.run_async(...):
+            if event.content and event.content.parts:
+                for part in event.content.parts:
+                    if part.text:
+                        events.append({"content": {"parts": [{"text": part.text}]}})
+        return events
+
+    for event_dict in asyncio.run(collect_events()):
+        yield event_dict
+```
+
+## イベント dict 形式
+
+`AgentEngineClient.extract_text()` が期待する形式:
+```python
+{"content": {"parts": [{"text": "response text"}]}}
+```

--- a/.steering/20260213-fix-agent-engine-missing-methods/requirements.md
+++ b/.steering/20260213-fix-agent-engine-missing-methods/requirements.md
@@ -1,0 +1,42 @@
+# Requirements - AgentEngine ラッパーメソッド追加
+
+## 背景・目的
+
+フロントエンドからメッセージ送信時に `'AgentEngine' object has no attribute 'async_stream_query'` エラーが発生する。
+
+`HomeworkCoachAgent` ラッパーに `query()` メソッドしかなく、Agent Engine クライアント (`agent_engine_client.py`) が必要とする `create_session` / `stream_query` メソッドが存在しない。
+
+Agent Engine プロキシ (`agent_engines.get()`) は、デプロイ済みオブジェクトの sync メソッドから `async_*` を自動生成するため、sync 版を定義すれば解決する。
+
+## 要求事項
+
+### 機能要件
+
+- `HomeworkCoachAgent.create_session(*, user_id: str) -> dict` を追加
+- `HomeworkCoachAgent.stream_query(*, user_id: str, session_id: str, message: str) -> Generator` を追加
+- `AgentEngineClient.extract_text()` が期待する `{"content": {"parts": [{"text": "..."}]}}` 形式を返す
+
+### 非機能要件
+
+- 既存の `query()` メソッドに影響しない
+- cloudpickle でシリアライズ可能であること
+
+### 制約条件
+
+- Agent Engine プロキシが `async_*` を自動生成するため sync 版のみ定義
+
+## 対象範囲
+
+### In Scope
+
+- `backend/scripts/serialize_agent.py` の `HomeworkCoachAgent` クラス修正
+
+### Out of Scope
+
+- `agent_engine_client.py` の変更
+- デプロイスクリプトの変更
+
+## 成功基準
+
+- lint / type check がパス
+- 再デプロイ後 `async_create_session` / `async_stream_query` がエラーなく動作

--- a/.steering/20260213-fix-agent-engine-missing-methods/tasklist.md
+++ b/.steering/20260213-fix-agent-engine-missing-methods/tasklist.md
@@ -1,0 +1,18 @@
+# Task List - AgentEngine ラッパーメソッド追加
+
+## Phase 1: 実装
+
+- [x] `HomeworkCoachAgent` に `create_session()` メソッドを追加
+- [x] `HomeworkCoachAgent` に `stream_query()` メソッドを追加
+- [x] 既存コードに型注釈を追加（`__init__`, `_get_runner`, `query` 内部関数）
+
+## Phase 2: 品質チェック
+
+- [x] `uv run ruff check backend/scripts/serialize_agent.py` → PASS
+- [x] `uv run mypy backend/scripts/serialize_agent.py` → PASS
+- [x] バックエンド全体品質チェック → ruff PASS, pytest PASS (590), mypy pre-existing error only
+
+## Phase 3: ドキュメント・PR
+
+- [ ] ドキュメント更新
+- [ ] コミット・プッシュ・PR作成

--- a/backend/scripts/serialize_agent.py
+++ b/backend/scripts/serialize_agent.py
@@ -11,8 +11,12 @@ Output:
     - pickle.pkl: シリアライズされたエージェント
 """
 
+from __future__ import annotations
+
 import os
 import sys
+from collections.abc import Generator
+from typing import Any
 
 # backend ディレクトリを PYTHONPATH に追加
 backend_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -32,6 +36,7 @@ def main() -> None:
         print("Creating AgentEngine-compatible wrapper...")
 
         from google.adk import Runner
+        from google.adk.agents import Agent
         from google.genai import types
 
         from app.services.adk.memory.memory_factory import create_memory_service
@@ -42,15 +47,16 @@ def main() -> None:
         class HomeworkCoachAgent:
             """Agent wrapper for Agent Engine deployment
 
-            This class exposes a simple query() method that the Agent Engine
-            can call via its REST API.
+            Agent Engine プロキシ (agent_engines.get()) は、デプロイ済みオブジェクトの
+            sync メソッド (create_session, stream_query) から async_create_session,
+            async_stream_query を自動生成する。そのため sync 版のみ定義すればよい。
             """
 
-            def __init__(self, agent):
+            def __init__(self, agent: Agent) -> None:
                 self._agent = agent
-                self._runner = None  # Lazy initialization
+                self._runner: Runner | None = None  # Lazy initialization
 
-            def _get_runner(self):
+            def _get_runner(self) -> Runner:
                 """Lazy initialization of Runner (after deserialization)"""
                 if self._runner is None:
                     session_service = create_session_service()
@@ -62,6 +68,83 @@ def main() -> None:
                         memory_service=memory_service,
                     )
                 return self._runner
+
+            def create_session(self, *, user_id: str) -> dict[str, Any]:
+                """Agent Engine 用のセッションを作成する
+
+                Agent Engine プロキシが async_create_session を自動生成するため、
+                sync 版のみ定義する。
+
+                Args:
+                    user_id: ユーザーID
+
+                Returns:
+                    セッション情報 {"id": session_id}
+                """
+                import asyncio
+
+                runner = self._get_runner()
+
+                session = asyncio.run(
+                    runner.session_service.create_session(
+                        app_name="homework-coach-agent-engine",
+                        user_id=user_id,
+                    )
+                )
+                return {"id": session.id}
+
+            def stream_query(
+                self,
+                *,
+                user_id: str,
+                session_id: str,
+                message: str,
+            ) -> Generator[dict[str, Any], None, None]:
+                """Agent Engine にクエリを送信しストリーミングで応答を返す
+
+                Agent Engine プロキシが async_stream_query を自動生成するため、
+                sync 版のみ定義する。各イベントは AgentEngineClient.extract_text()
+                が期待する {"content": {"parts": [{"text": "..."}]}} 形式で返す。
+
+                Args:
+                    user_id: ユーザーID
+                    session_id: セッションID
+                    message: ユーザーメッセージ
+
+                Yields:
+                    イベント辞書
+                """
+                import asyncio
+
+                runner = self._get_runner()
+
+                # Content を作成
+                content = types.Content(
+                    role="user",
+                    parts=[types.Part(text=message)],
+                )
+
+                # 非同期イベントを同期的に収集し、dict 形式で yield
+                async def collect_events() -> list[dict[str, Any]]:
+                    events: list[dict[str, Any]] = []
+                    async for event in runner.run_async(
+                        user_id=user_id,
+                        session_id=session_id,
+                        new_message=content,
+                    ):
+                        if event.content and event.content.parts:
+                            for part in event.content.parts:
+                                if part.text:
+                                    events.append(
+                                        {
+                                            "content": {
+                                                "parts": [{"text": part.text}],
+                                            },
+                                        }
+                                    )
+                    return events
+
+                yield from asyncio.run(collect_events())
 
             def query(self, message: str) -> str:
                 """Query the agent with a message
@@ -81,9 +164,9 @@ def main() -> None:
                 )
 
                 # Run agent and collect response
-                async def run_query():
+                async def run_query() -> str:
                     runner = self._get_runner()
-                    response_texts = []
+                    response_texts: list[str] = []
                     async for event in runner.run_async(
                         user_id="api-user",
                         session_id="api-session",

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -43,6 +43,7 @@
 - **Phase 2 Backend WebSocketイベント送信**: `voice_stream.py` に Phase 2 イベント型（ToolExecution, AgentTransition, EmotionUpdate）追加、`streaming_service.py` にイベント変換ロジック実装、統合テスト（13テスト、345テスト総数）
 - **CI/CD Agent Engineアーティファクト自動デプロイ**: cd.yml に `deploy-agent-engine` ジョブ追加、バックエンド変更検知（git diff）、エージェントシリアライズ（serialize_agent.py）、依存関係パッケージ化、GCSアップロード（pickle.pkl, requirements.txt, dependencies.tar.gz）、条件付き実行（バックエンド変更時のみ）、エラーハンドリング実装完了
 - **GCS権限修正 + CDワークフロー改善**: GitHub Actions SA に `roles/storage.objectAdmin` を Terraform（IAM モジュール）で付与、CDワークフロー（cd.yml）で `gcloud storage buckets list` を廃止し `GCS_ASSETS_BUCKET` GitHub Secret で直接バケット名を参照するように変更
+- **Agent Engine ラッパーメソッド追加 (Issue #114)**: `serialize_agent.py` の `HomeworkCoachAgent` に `create_session()` / `stream_query()` メソッドを追加。Agent Engine プロキシが `async_create_session` / `async_stream_query` を自動生成できるように修正。既存コードの型注釈も改善
 
 ---
 
@@ -884,3 +885,4 @@ GCPプロジェクト `homework-coach-robo` にデプロイ済み。
 | `.steering/20260211-ci-cd-agent-engine-deploy/` | CI/CD Agent Engineアーティファクト自動デプロイ |
 | `.steering/20260211-agent-engine-terraform/` | Phase 3 Agent Engine Terraform インフラ整備 |
 | `.steering/20260213-fix-gcs-permissions/` | GCS 権限修正 + CD ワークフロー改善 |
+| `.steering/20260213-fix-agent-engine-missing-methods/` | Agent Engine ラッパーメソッド追加（create_session / stream_query） |


### PR DESCRIPTION
## Summary

- `HomeworkCoachAgent` に `create_session()` と `stream_query()` メソッドを追加
- Agent Engine プロキシが `async_create_session` / `async_stream_query` を自動生成できるように修正
- 既存コードの型注釈を改善（`__init__`, `_get_runner`, `query` 内部関数）

Closes #114

## 背景

フロントエンドからメッセージ送信時に `'AgentEngine' object has no attribute 'async_stream_query'` エラーが発生していた。`HomeworkCoachAgent` ラッパーに `query()` メソッドしかなく、`AgentEngineClient` が必要とする `create_session` / `stream_query` が未定義だった。

Agent Engine プロキシ (`agent_engines.get()`) は sync メソッドから `async_*` を自動生成するため、sync 版を定義することで解決。

## Test plan

- [x] `uv run ruff check scripts/serialize_agent.py` → PASS
- [x] `uv run mypy scripts/serialize_agent.py` → PASS
- [x] `uv run pytest tests/ -v` → 590 passed
- [ ] 再デプロイ後に `test_agent_engine.py` で動作確認（Agent Engine 環境が必要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)