### PR TITLE
fix(infra): Agent Engine更新APIを修正

### DIFF
--- a/backend/scripts/deploy_agent_engine.py
+++ b/backend/scripts/deploy_agent_engine.py
@@ -105,6 +105,9 @@ def agent_engines_update(
 ) -> object:
     """既存の Agent Engine を更新する
 
+    client.agent_engines.update() を使用して既存のインスタンスを更新する。
+    vertexai.init() は呼び出し元の deploy_agent() で設定済み。
+
     Args:
         resource_name: 既存リソース名
         agent: HomeworkCoachAgent インスタンス
@@ -113,10 +116,11 @@ def agent_engines_update(
     Returns:
         更新後の remote_app
     """
-    from vertexai import agent_engines
+    import vertexai
 
-    remote_app = agent_engines.get(resource_name)
-    remote_app.update(  # type: ignore[call-arg]
+    client = vertexai.Client()
+    remote_app = client.agent_engines.update(
+        name=resource_name,
         agent=agent,
         config={
             "staging_bucket": f"gs://{staging_bucket}",


### PR DESCRIPTION
## Summary
- `agent_engines.get()`で取得したインスタンスの`.update()`メソッドは`agent`パラメータを受け付けないため`TypeError`が発生していた
- `client.agent_engines.update()`を使用するように修正（create パスと同じパターン）
- CD パイプラインの Agent Engine 更新ステップが正常に動作するようになる

## Context
- PR #127 で IAM 権限（`roles/aiplatform.user`）を追加し、403エラーを解消
- その後、`TypeError: AgentEngine.update() got an unexpected keyword argument 'agent'` が発生
- 原因: インスタンスメソッドとモジュールレベル関数の API の違い

## Test plan
- [ ] CD パイプラインの `deploy-agent-engine` ジョブが成功することを確認
- [ ] Agent Engine の `updateTime` が更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)