### PR TITLE
chore(backend): Agent Engine診断ログを追加

### DIFF
--- a/backend/app/api/v1/dialogue_runner.py
+++ b/backend/app/api/v1/dialogue_runner.py
@@ -166,9 +166,7 @@ async def agent_engine_event_generator(
                     str(event)[:200],
                 )
 
-        logger.info(
-            "Agent Engine stream completed: %d events received", event_count
-        )
+        logger.info("Agent Engine stream completed: %d events received", event_count)
         done_event = DoneEvent(session_id=session_id)
         yield f"event: done\ndata: {done_event.model_dump_json()}\n\n"
 

--- a/backend/app/services/adk/runner/homework_coach_agent.py
+++ b/backend/app/services/adk/runner/homework_coach_agent.py
@@ -163,7 +163,7 @@ class HomeworkCoachAgent:
                         has_content,
                         getattr(event, "author", "unknown"),
                     )
-                    if has_content:
+                    if has_content and event.content and event.content.parts:
                         for part in event.content.parts:
                             if part.text:
                                 events.append(


### PR DESCRIPTION
## Summary
- イベントループ修正（PR #136）後も応答が空の原因を特定するための診断ログを追加
- `HomeworkCoachAgent._run_coroutine_sync`: イベントループ検出・スレッド実行状況
- `HomeworkCoachAgent.stream_query.collect_events`: `run_async` のイベント受信数・エラー詳細
- `agent_engine_event_generator`: 受信イベント数・型・`extract_text` 失敗時の内容出力

## 背景
PR #136 でイベントループ競合を修正しデプロイしたが、`/api/v1/dialogue/run` は依然として `event: done` のみを返し、テキスト応答が表示されない。例外も発生していないため、Agent Engine 内部で何が起きているかを可視化する必要がある。

## Test plan
- [x] 既存16テスト全パス
- [ ] デプロイ後に Cloud Run ログで Agent Engine イベントの詳細を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)