### PR TITLE
fix(infra): フロントエンドDockerfileのBunバージョンを1.2にピン留め

### DIFF
--- a/infrastructure/docker/frontend/Dockerfile
+++ b/infrastructure/docker/frontend/Dockerfile
@@ -2,7 +2,7 @@
 # Next.js application with Bun runtime
 
 # Build stage
-FROM oven/bun:1 as builder
+FROM oven/bun:1.2 AS builder
 
 # Set working directory
 WORKDIR /app
@@ -24,7 +24,7 @@ ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
 RUN bun run build
 
 # Production stage
-FROM oven/bun:1-slim as production
+FROM oven/bun:1.2-slim AS production
 
 # Create non-root user for security
 RUN groupadd -r appgroup && useradd -r -g appgroup appuser


### PR DESCRIPTION
## Summary
- `oven/bun:1` → `oven/bun:1.2` にピン留め（ビルド・ランタイム両方）
- Bun 1.3.9 の Docker 環境でのセグメンテーションフォルトを回避
- `as` → `AS` の Dockerfile 構文警告も修正

## 背景
`oven/bun:1` が Bun 1.3.9 に解決され、Next.js ビルド完了後のクリーンアップ時にセグフォルトが発生しフロントエンドデプロイが失敗していた。Bun 1.3.x の既知バグのため、安定版の 1.2 系にピン留めする。

## Test plan
- [ ] CD でフロントエンドの Docker ビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)