### PR TITLE
fix(infra,backend): 音声入力の応答なし問題を修正

### DIFF
--- a/.steering/20260214-voice-input-fix/design.md
+++ b/.steering/20260214-voice-input-fix/design.md
@@ -1,0 +1,59 @@
+# Design - 音声入力が応答しない問題の修正
+
+## 根本原因分析
+
+### 原因1: genai環境変数の不足（Critical）
+
+Cloud Run バックエンドに以下の環境変数が設定されていない：
+
+| 必要な環境変数 | 目的 | 現状 |
+|---|---|---|
+| `GOOGLE_GENAI_USE_VERTEXAI` | genaiライブラリにVertex AI使用を指示 | **未設定** |
+| `GOOGLE_CLOUD_PROJECT` | genaiライブラリのプロジェクト指定 | **未設定**（`GCP_PROJECT_ID`は別名） |
+| `GOOGLE_CLOUD_LOCATION` | genaiライブラリのリージョン指定 | **未設定**（`GCP_REGION`は別名、且つasia-northeast1） |
+
+ADK `Runner.run_live()` は内部で `genai.Client()` を使用し、
+これらの環境変数を参照する。未設定の場合、Vertex AI Gemini APIに接続できずエラーになる。
+
+### 原因2: WebSocketエラーハンドリングの不備（High）
+
+`voice_stream.py` の `_agent_to_client()` 関数でエラーが発生しても、
+フロントエンドにエラーが通知されない（ログ出力のみ）。
+
+## 修正方針
+
+### Fix 1: Terraform でgenai環境変数を追加
+
+`infrastructure/terraform/modules/cloud_run/main.tf` に以下を追加：
+
+```hcl
+env {
+  name  = "GOOGLE_GENAI_USE_VERTEXAI"
+  value = "TRUE"
+}
+env {
+  name  = "GOOGLE_CLOUD_PROJECT"
+  value = var.project_id
+}
+env {
+  name  = "GOOGLE_CLOUD_LOCATION"
+  value = var.vertex_ai_location
+}
+```
+
+`vertex_ai_location` はGeminiモデルが利用可能なリージョン（デフォルト: `us-central1`）。
+Cloud Run のデプロイリージョン（`asia-northeast1`）とは異なる。
+
+### Fix 2: WebSocketエラーハンドリング改善
+
+`voice_stream.py` の `_agent_to_client()` で例外発生時に
+WebSocketでエラーメッセージをクライアントに送信する。
+
+## ファイル構成
+
+変更対象：
+1. `infrastructure/terraform/modules/cloud_run/main.tf` - genai環境変数追加
+2. `infrastructure/terraform/modules/cloud_run/variables.tf` - vertex_ai_location変数追加
+3. `infrastructure/terraform/environments/dev/main.tf` - vertex_ai_location値渡し
+4. `backend/app/api/v1/voice_stream.py` - エラーハンドリング改善
+5. `backend/tests/unit/api/v1/test_voice_stream.py` - テスト追加（TDD）

--- a/.steering/20260214-voice-input-fix/requirements.md
+++ b/.steering/20260214-voice-input-fix/requirements.md
@@ -1,0 +1,40 @@
+# Requirements - 音声入力が応答しない問題の修正
+
+## 背景・目的
+
+デプロイ済みアプリで「話しかける」ボタンを押して音声入力しても応答がない。
+音量メーターは動いている（=マイク取得・AudioWorklet・WebSocket接続は成功）が、
+AIからの応答が返ってこない。
+
+## 要求事項
+
+### 機能要件
+
+- 音声入力後、AIが応答すること（音声+トランスクリプション）
+- エラー発生時にフロントエンドにエラーが通知されること
+
+### 非機能要件
+
+- Cloud Run バックエンドで Gemini Live API が正常に動作すること
+
+### 制約条件
+
+- Gemini Live APIモデルはus-central1リージョンで利用可能（Cloud Runはasia-northeast1）
+
+## 対象範囲
+
+### In Scope
+
+1. Cloud Run バックエンドに genai 環境変数を追加（Terraform）
+2. WebSocket エラーハンドリング改善（バックエンド→フロントエンドへのエラー通知）
+
+### Out of Scope
+
+- 認証・認可の実装
+- WebSocket URLの別設定（NEXT_PUBLIC_WS_URL）
+- Cloud Runのタイムアウト延長（別issueで対応）
+
+## 成功基準
+
+- デプロイ後、音声入力に対してAIが応答を返す
+- エラー発生時にフロントエンドにエラーメッセージが表示される

--- a/.steering/20260214-voice-input-fix/tasklist.md
+++ b/.steering/20260214-voice-input-fix/tasklist.md
@@ -1,0 +1,19 @@
+# Task List - 音声入力が応答しない問題の修正
+
+## Phase 1: Terraform修正（genai環境変数追加）
+
+- [ ] `modules/cloud_run/variables.tf` に `vertex_ai_location` 変数を追加
+- [ ] `modules/cloud_run/main.tf` にgenai環境変数3つを追加
+- [ ] `environments/dev/main.tf` で `vertex_ai_location` を渡す
+- [ ] `terraform init -backend=false && terraform validate` で検証
+
+## Phase 2: バックエンドエラーハンドリング改善（TDD）
+
+- [ ] `voice_stream.py` の `_agent_to_client()` でエラーをクライアントに送信
+- [ ] テスト追加
+
+## Phase 3: 品質チェック
+
+- [ ] Terraform validate 通過
+- [ ] Backend pytest 通過
+- [ ] コミット・プッシュ・PR作成

--- a/infrastructure/terraform/environments/dev/main.tf
+++ b/infrastructure/terraform/environments/dev/main.tf
@@ -164,6 +164,7 @@ module "cloud_run" {
   backend_min_instances             = var.backend_min_instances
   frontend_min_instances            = var.frontend_min_instances
   backend_memory                    = var.backend_memory
+  vertex_ai_location                = var.gcp_location
 
   # Pass secret references to backend
   backend_secrets = {

--- a/infrastructure/terraform/modules/cloud_run/main.tf
+++ b/infrastructure/terraform/modules/cloud_run/main.tf
@@ -61,6 +61,20 @@ resource "google_cloud_run_v2_service" "backend" {
         name  = "GCP_REGION"
         value = var.region
       }
+
+      # genai / ADK Runner が Vertex AI Gemini API に接続するために必要
+      env {
+        name  = "GOOGLE_GENAI_USE_VERTEXAI"
+        value = "TRUE"
+      }
+      env {
+        name  = "GOOGLE_CLOUD_PROJECT"
+        value = var.project_id
+      }
+      env {
+        name  = "GOOGLE_CLOUD_LOCATION"
+        value = var.vertex_ai_location
+      }
       # NOTE: PORT is automatically set by Cloud Run (8080)
 
       # CORS: フロントエンドCloud Run URLを許可

--- a/infrastructure/terraform/modules/cloud_run/variables.tf
+++ b/infrastructure/terraform/modules/cloud_run/variables.tf
@@ -146,6 +146,13 @@ variable "frontend_concurrency" {
   default     = 80
 }
 
+# Vertex AI location for Gemini API (may differ from Cloud Run region)
+variable "vertex_ai_location" {
+  description = "GCP location for Vertex AI / Gemini API (e.g. us-central1)"
+  type        = string
+  default     = "us-central1"
+}
+
 # Backend additional environment variables (Phase 2)
 variable "backend_env_vars" {
   description = "Additional environment variables for backend service"


### PR DESCRIPTION
## Summary

- Cloud Run バックエンドに genai 環境変数（`GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`）を追加し、`Runner.run_live()` が Gemini Live API に接続できるようにした
- WebSocket エラーハンドリングを改善し、バックエンドのエラーがフロントエンドに通知されるようにした
- エラーハンドリングテスト3件追加（合計12テスト）

## 根本原因

音声ストリーミングパスの `VoiceStreamingService` → `Runner.run_live()` は内部で `genai.Client()` を使用するが、Cloud Run 環境に genai ライブラリが必要とする環境変数が未設定だった。`GCP_PROJECT_ID` / `GCP_REGION` は設定されていたが、genai は `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` という別名の変数を参照するため、接続に失敗していた。

さらに、`_agent_to_client()` のエラーハンドリングがログ出力のみでフロントエンドへの通知がなく、サイレント失敗していた。

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `modules/cloud_run/main.tf` | genai環境変数3つ追加 |
| `modules/cloud_run/variables.tf` | `vertex_ai_location` 変数追加 |
| `environments/dev/main.tf` | `vertex_ai_location` 値を渡す |
| `backend/app/api/v1/voice_stream.py` | エラーハンドリング改善（3箇所） |
| `backend/tests/unit/api/v1/test_voice_stream.py` | エラーハンドリングテスト3件追加 |

## Test plan

- [x] Terraform validate 通過
- [x] 既存テスト9件通過
- [x] 新規テスト3件通過（合計12件）
- [x] Ruff lint / format 通過
- [ ] CD デプロイ後に音声入力で応答があること確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)